### PR TITLE
Implemented optional C++ exceptions in Error class

### DIFF
--- a/doc/src/Section_start.txt
+++ b/doc/src/Section_start.txt
@@ -262,6 +262,7 @@ within the LAMMPS code.  The options that are currently recogized are:
 -DLAMMPS_BIGBIG
 -DLAMMPS_SMALLSMALL
 -DLAMMPS_LONGLONG_TO_LONG
+-DLAMMPS_EXCEPTIONS
 -DPACK_ARRAY
 -DPACK_POINTER
 -DPACK_MEMCPY :ul
@@ -333,6 +334,14 @@ The -DLAMMPS_LONGLONG_TO_LONG setting may be needed if your system or
 MPI version does not recognize "long long" data types.  In this case a
 "long" data type is likely already 64-bits, in which case this setting
 will convert to that data type.
+
+The -DLAMMPS_EXCEPTIONS setting can be used to activate alternative
+versions of error handling inside of LAMMPS. This is useful for external
+codes driving LAMMPS as a library. Using this option, errors do not exit
+the driving process. Instead, the call stack is unwinded and the library
+functions can return. The library interface provides the lammps_has_error
+and lammps_get_last_error_message functions to detect and find out more
+about an LAMMPS error.
 
 Using one of the -DPACK_ARRAY, -DPACK_POINTER, and -DPACK_MEMCPY
 options can make for faster parallel FFTs (in the PPPM solver) on some

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -150,6 +150,11 @@ class lammps(object):
     if cmd: cmd = cmd.encode()
     self.lib.lammps_command(self.lmp,cmd)
 
+    if self.lib.lammps_has_error(self.lmp):
+      sb = create_string_buffer(100)
+      self.lib.lammps_get_last_error_message(self.lmp, sb, 100)
+      raise Exception(sb.value.decode().strip())
+
   def extract_global(self,name,type):
     if name: name = name.encode()
     if type == 0:

--- a/src/error.h
+++ b/src/error.h
@@ -15,10 +15,41 @@
 #define LMP_ERROR_H
 
 #include "pointers.h"
+#include <string>
+#include <exception>
 
 namespace LAMMPS_NS {
 
+class LAMMPSException : public std::exception
+{
+public:
+  std::string message;
+
+  LAMMPSException(std::string msg) : message(msg) {
+  }
+
+  ~LAMMPSException() throw() {
+  }
+
+  virtual const char * what() const throw() {
+    return message.c_str();
+  }
+};
+
+class LAMMPSAbortException : public LAMMPSException {
+public:
+  MPI_Comm universe;
+
+  LAMMPSAbortException(std::string msg, MPI_Comm universe) :
+    LAMMPSException(msg),
+    universe(universe)
+  {
+  }
+};
+
 class Error : protected Pointers {
+  char * last_error_message;
+
  public:
   Error(class LAMMPS *);
 
@@ -31,6 +62,9 @@ class Error : protected Pointers {
   void warning(const char *, int, const char *, int = 1);
   void message(const char *, int, const char *, int = 1);
   void done(int = 0); // 1 would be fully backwards compatible
+
+  char * get_last_error() const;
+  void   set_last_error(const char * msg);
 };
 
 }

--- a/src/library.h
+++ b/src/library.h
@@ -45,6 +45,9 @@ int lammps_get_natoms(void *);
 void lammps_gather_atoms(void *, char *, int, int, void *);
 void lammps_scatter_atoms(void *, char *, int, int, void *);
 
+int lammps_has_error(void *);
+int lammps_get_last_error_message(void *, char *, int);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,9 @@
 #include <mpi.h>
 #include "lammps.h"
 #include "input.h"
+#include "error.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 using namespace LAMMPS_NS;
 
@@ -26,11 +28,22 @@ int main(int argc, char **argv)
 {
   MPI_Init(&argc,&argv);
 
+#ifdef LAMMPS_EXCEPTIONS
+  try {
+    LAMMPS *lammps = new LAMMPS(argc,argv,MPI_COMM_WORLD);
+    lammps->input->file();
+    delete lammps;
+  } catch(LAMMPSAbortException & ae) {
+    MPI_Abort(ae.universe, 1);
+  } catch(LAMMPSException & e) {
+    MPI_Finalize();
+    exit(1);
+  }
+#else
   LAMMPS *lammps = new LAMMPS(argc,argv,MPI_COMM_WORLD);
-
   lammps->input->file();
   delete lammps;
-
+#endif
   MPI_Barrier(MPI_COMM_WORLD);
   MPI_Finalize();
 }


### PR DESCRIPTION
These can be activated using the `-DLAMMPS_EXCEPTIONS` compiler flag.
It has no effect for regular execution. However, while using
it as a library, any issued command will capture the exception
and save its error message. This can be queried using the
lammps_has_error() and lammps_get_last_error_message() methods.

The Python wrapper checks these in order to rethrow these errors
as Python exceptions. See issue #146.

(cherry picked from commit 6c154bb0b67a13d38968bc42d31013b97f87db75)
