### PR TITLE
enforce initializing pointers in constructors to NULL

### DIFF
--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -41,7 +41,7 @@ int Compute::instance_total = 0;
 Compute::Compute(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp),
   id(NULL), style(NULL),
   vector(NULL), array(NULL), vector_atom(NULL), array_atom(NULL), vector_local(NULL), array_local(NULL),
-  tlist(NULL)
+  tlist(NULL), vbiasall(NULL)
 {
   instance_me = instance_total++;
   

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -38,10 +38,13 @@ int Compute::instance_total = 0;
 
 /* ---------------------------------------------------------------------- */
 
-Compute::Compute(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
+Compute::Compute(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp),
+  id(NULL), style(NULL),
+  vector(NULL), array(NULL), vector_atom(NULL), array_atom(NULL), vector_local(NULL), array_local(NULL),
+  tlist(NULL)
 {
   instance_me = instance_total++;
-
+  
   if (narg < 3) error->all(FLERR,"Illegal compute command");
 
   // compute ID, group, and style
@@ -93,8 +96,7 @@ Compute::Compute(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   // setup list of timesteps
 
   ntime = maxtime = 0;
-  tlist = NULL;
-
+  
   // data masks
 
   datamask = ALL_MASK;
@@ -105,11 +107,6 @@ Compute::Compute(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   datamask_modify = ALL_MASK;
 
   copymode = 0;
-
-  // force init to zero in case these are used as logicals
-
-  vector = vector_atom = vector_local = NULL;
-  array = array_atom = array_local = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_angle.cpp
+++ b/src/compute_angle.cpp
@@ -24,7 +24,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeAngle::ComputeAngle(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  emine(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute angle command");
 

--- a/src/compute_angle_local.cpp
+++ b/src/compute_angle_local.cpp
@@ -33,7 +33,8 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 ComputeAngleLocal::ComputeAngleLocal(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  vector(NULL), array(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute angle/local command");
 
@@ -55,8 +56,6 @@ ComputeAngleLocal::ComputeAngleLocal(LAMMPS *lmp, int narg, char **arg) :
   }
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_angmom_chunk.cpp
+++ b/src/compute_angmom_chunk.cpp
@@ -26,7 +26,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeAngmomChunk::ComputeAngmomChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), angmom(NULL), angmomall(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute angmom/chunk command");
 
@@ -48,9 +49,6 @@ ComputeAngmomChunk::ComputeAngmomChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  com = comall = NULL;
-  angmom = angmomall = NULL;
   allocate();
 }
 

--- a/src/compute_bond.cpp
+++ b/src/compute_bond.cpp
@@ -24,7 +24,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeBond::ComputeBond(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  emine(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute bond command");
 

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -33,7 +33,8 @@ enum{DIST,ENG,FORCE};
 /* ---------------------------------------------------------------------- */
 
 ComputeBondLocal::ComputeBondLocal(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  bstyle(NULL), vector(NULL), array(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute bond/local command");
 
@@ -62,8 +63,6 @@ ComputeBondLocal::ComputeBondLocal(LAMMPS *lmp, int narg, char **arg) :
     if (bstyle[i] != DIST) singleflag = 1;
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_centro_atom.cpp
+++ b/src/compute_centro_atom.cpp
@@ -36,7 +36,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeCentroAtom::ComputeCentroAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  distsq(NULL), nearest(NULL), centro(NULL)
 {
   if (narg < 4 || narg > 6) error->all(FLERR,"Illegal compute centro/atom command");
 
@@ -69,11 +70,7 @@ ComputeCentroAtom::ComputeCentroAtom(LAMMPS *lmp, int narg, char **arg) :
   else size_peratom_cols = 10;
   
   nmax = 0;
-  centro = NULL;
   maxneigh = 0;
-  distsq = NULL;
-  nearest = NULL;
-  array_atom = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -56,7 +56,10 @@ ComputeChunkAtom *ComputeChunkAtom::cptr;
 /* ---------------------------------------------------------------------- */
 
 ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_fix(NULL), chunk(NULL), ichunk(NULL), exclude(NULL),
+  chunk_volume_vec(NULL), coord(NULL), chunkID(NULL), idregion(NULL), cfvid(NULL), 
+  hash(NULL), varatom(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute chunk/atom command");
 

--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -34,7 +34,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeClusterAtom::ComputeClusterAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  clusterID(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute cluster/atom command");
 
@@ -46,7 +47,6 @@ ComputeClusterAtom::ComputeClusterAtom(LAMMPS *lmp, int narg, char **arg) :
   comm_forward = 1;
 
   nmax = 0;
-  clusterID = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_cna_atom.cpp
+++ b/src/compute_cna_atom.cpp
@@ -42,7 +42,8 @@ enum{NCOMMON,NBOND,MAXBOND,MINBOND};
 /* ---------------------------------------------------------------------- */
 
 ComputeCNAAtom::ComputeCNAAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  nearest(NULL), nnearest(NULL), pattern(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute cna/atom command");
 
@@ -54,9 +55,6 @@ ComputeCNAAtom::ComputeCNAAtom(LAMMPS *lmp, int narg, char **arg) :
   cutsq = cutoff*cutoff;
 
   nmax = 0;
-  nearest = NULL;
-  nnearest = NULL;
-  pattern = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_com_chunk.cpp
+++ b/src/compute_com_chunk.cpp
@@ -28,7 +28,8 @@ enum{ONCE,NFREQ,EVERY};
 /* ---------------------------------------------------------------------- */
 
 ComputeCOMChunk::ComputeCOMChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), masstotal(NULL), massproc(NULL), com(NULL), comall(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute com/chunk command");
 
@@ -50,8 +51,6 @@ ComputeCOMChunk::ComputeCOMChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  com = comall = NULL;
   allocate();
 
   firstflag = massneed = 1;

--- a/src/compute_contact_atom.cpp
+++ b/src/compute_contact_atom.cpp
@@ -32,7 +32,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeContactAtom::ComputeContactAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  contact(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute contact/atom command");
 
@@ -41,7 +42,6 @@ ComputeContactAtom::ComputeContactAtom(LAMMPS *lmp, int narg, char **arg) :
   comm_reverse = 1;
 
   nmax = 0;
-  contact = NULL;
 
   // error checks
 

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -32,7 +32,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeCoordAtom::ComputeCoordAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  typelo(NULL), typehi(NULL), cvec(NULL), carray(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute coord/atom command");
 
@@ -65,8 +66,6 @@ ComputeCoordAtom::ComputeCoordAtom(LAMMPS *lmp, int narg, char **arg) :
   else size_peratom_cols = ncol;
 
   nmax = 0;
-  cvec = NULL;
-  carray = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_dihedral.cpp
+++ b/src/compute_dihedral.cpp
@@ -24,7 +24,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeDihedral::ComputeDihedral(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  emine(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute dihedral command");
 

--- a/src/compute_dihedral_local.cpp
+++ b/src/compute_dihedral_local.cpp
@@ -34,7 +34,8 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 ComputeDihedralLocal::ComputeDihedralLocal(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  vector(NULL), array(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute dihedral/local command");
 
@@ -56,8 +57,6 @@ ComputeDihedralLocal::ComputeDihedralLocal(LAMMPS *lmp, int narg, char **arg) :
   }
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_dipole_chunk.cpp
+++ b/src/compute_dipole_chunk.cpp
@@ -30,7 +30,9 @@ enum { MASSCENTER, GEOMCENTER };
 /* ---------------------------------------------------------------------- */
 
 ComputeDipoleChunk::ComputeDipoleChunk(LAMMPS *lmp, int narg, char **arg) : 
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), chrgproc(NULL), chrgtotal(NULL), com(NULL),
+  comall(NULL), dipole(NULL), dipoleall(NULL)
 {
   if ((narg != 4) && (narg != 5)) error->all(FLERR,"Illegal compute dipole/chunk command");
 
@@ -60,10 +62,6 @@ ComputeDipoleChunk::ComputeDipoleChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  chrgproc = chrgtotal = NULL;
-  com = comall = NULL;
-  dipole = dipoleall = NULL;
   allocate();
 }
 

--- a/src/compute_displace_atom.cpp
+++ b/src/compute_displace_atom.cpp
@@ -29,7 +29,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeDisplaceAtom::ComputeDisplaceAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_fix(NULL), displace(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute displace/atom command");
 
@@ -76,7 +77,6 @@ ComputeDisplaceAtom::ComputeDisplaceAtom(LAMMPS *lmp, int narg, char **arg) :
   // per-atom displacement array
 
   nmax = 0;
-  displace = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_erotate_sphere_atom.cpp
+++ b/src/compute_erotate_sphere_atom.cpp
@@ -29,7 +29,8 @@ using namespace LAMMPS_NS;
 
 ComputeErotateSphereAtom::
 ComputeErotateSphereAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  erot(NULL)
 {
   if (narg != 3)
     error->all(FLERR,"Illegal compute erotate/sphere//atom command");
@@ -43,7 +44,6 @@ ComputeErotateSphereAtom(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Compute erotate/sphere/atom requires atom style sphere");
 
   nmax = 0;
-  erot = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_group_group.cpp
+++ b/src/compute_group_group.cpp
@@ -42,7 +42,8 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 ComputeGroupGroup::ComputeGroupGroup(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  group2(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute group/group command");
 

--- a/src/compute_gyration_chunk.cpp
+++ b/src/compute_gyration_chunk.cpp
@@ -27,7 +27,9 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeGyrationChunk::ComputeGyrationChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), rg(NULL),
+  rgall(NULL), rgt(NULL), rgtall(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute gyration/chunk command");
 
@@ -67,10 +69,6 @@ ComputeGyrationChunk::ComputeGyrationChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  com = comall = NULL;
-  rg = rgall = NULL;
-  rgt = rgtall = NULL;
   allocate();
 }
 

--- a/src/compute_heat_flux.cpp
+++ b/src/compute_heat_flux.cpp
@@ -33,7 +33,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeHeatFlux::ComputeHeatFlux(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_ke(NULL), id_pe(NULL), id_stress(NULL)
 {
   if (narg != 6) error->all(FLERR,"Illegal compute heat/flux command");
 

--- a/src/compute_hexorder_atom.cpp
+++ b/src/compute_hexorder_atom.cpp
@@ -44,7 +44,8 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 ComputeHexOrderAtom::ComputeHexOrderAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  distsq(NULL), nearest(NULL), qnarray(NULL)
 {
   if (narg < 3 ) error->all(FLERR,"Illegal compute hexorder/atom command");
 
@@ -87,10 +88,7 @@ ComputeHexOrderAtom::ComputeHexOrderAtom(LAMMPS *lmp, int narg, char **arg) :
   size_peratom_cols = ncol;
 
   nmax = 0;
-  qnarray = NULL;
   maxneigh = 0;
-  distsq = NULL;
-  nearest = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_improper.cpp
+++ b/src/compute_improper.cpp
@@ -24,7 +24,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeImproper::ComputeImproper(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  emine(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute improper command");
 

--- a/src/compute_improper_local.cpp
+++ b/src/compute_improper_local.cpp
@@ -35,7 +35,8 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 ComputeImproperLocal::ComputeImproperLocal(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  vector(NULL), array(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute improper/local command");
 
@@ -57,8 +58,6 @@ ComputeImproperLocal::ComputeImproperLocal(LAMMPS *lmp, int narg, char **arg) :
   }
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_inertia_chunk.cpp
+++ b/src/compute_inertia_chunk.cpp
@@ -26,7 +26,9 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeInertiaChunk::ComputeInertiaChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL),
+  inertia(NULL), inertiaall(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute inertia/chunk command");
 
@@ -48,9 +50,6 @@ ComputeInertiaChunk::ComputeInertiaChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  com = comall = NULL;
-  inertia = inertiaall = NULL;
   allocate();
 }
 

--- a/src/compute_ke_atom.cpp
+++ b/src/compute_ke_atom.cpp
@@ -26,7 +26,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeKEAtom::ComputeKEAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  ke(NULL)
 {
   if (narg != 3) error->all(FLERR,"Illegal compute ke/atom command");
 
@@ -34,7 +35,6 @@ ComputeKEAtom::ComputeKEAtom(LAMMPS *lmp, int narg, char **arg) :
   size_peratom_cols = 0;
 
   nmax = 0;
-  ke = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_msd.cpp
+++ b/src/compute_msd.cpp
@@ -26,7 +26,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeMSD::ComputeMSD(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_fix(NULL)
 {
   if (narg < 3) error->all(FLERR,"Illegal compute msd command");
 

--- a/src/compute_msd_chunk.cpp
+++ b/src/compute_msd_chunk.cpp
@@ -28,7 +28,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeMSDChunk::ComputeMSDChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), id_fix(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), msd(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute msd/chunk command");
 
@@ -46,10 +47,6 @@ ComputeMSDChunk::ComputeMSDChunk(LAMMPS *lmp, int narg, char **arg) :
 
   firstflag = 1;
   init();
-
-  massproc = masstotal = NULL;
-  com = comall = NULL;
-  msd = NULL;
 
   // create a new fix STORE style for reference positions
   // id = compute-ID + COMPUTE_STORE, fix group = compute group

--- a/src/compute_omega_chunk.cpp
+++ b/src/compute_omega_chunk.cpp
@@ -26,7 +26,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeOmegaChunk::ComputeOmegaChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), angmom(NULL), angmomall(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute omega/chunk command");
 
@@ -48,9 +49,6 @@ ComputeOmegaChunk::ComputeOmegaChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  com = comall = NULL;
-  angmom = angmomall = NULL;
   allocate();
 }
 

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -45,7 +45,8 @@ using namespace std;
 /* ---------------------------------------------------------------------- */
 
 ComputeOrientOrderAtom::ComputeOrientOrderAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  distsq(NULL), nearest(NULL), rlist(NULL), qlist(NULL), qnarray(NULL), qnm_r(NULL), qnm_i(NULL)
 {
   if (narg < 3 ) error->all(FLERR,"Illegal compute orientorder/atom command");
 
@@ -109,13 +110,7 @@ ComputeOrientOrderAtom::ComputeOrientOrderAtom(LAMMPS *lmp, int narg, char **arg
   size_peratom_cols = ncol;
 
   nmax = 0;
-  qnarray = NULL;
   maxneigh = 0;
-  distsq = NULL;
-  nearest = NULL;
-  rlist = NULL;
-  qnm_r = NULL;
-  qnm_i = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_pair.cpp
+++ b/src/compute_pair.cpp
@@ -26,7 +26,8 @@ enum{EPAIR,EVDWL,ECOUL};
 /* ---------------------------------------------------------------------- */
 
 ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  pstyle(NULL), pair(NULL), one(NULL)
 {
   if (narg < 4 || narg > 5) error->all(FLERR,"Illegal compute pair command");
 

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -36,7 +36,8 @@ enum{TYPE,RADIUS};
 /* ---------------------------------------------------------------------- */
 
 ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  pstyle(NULL), pindex(NULL), vector(NULL), array(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute pair/local command");
 
@@ -96,8 +97,6 @@ ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
     if (pstyle[i] != DIST) singleflag = 1;
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_pe_atom.cpp
+++ b/src/compute_pe_atom.cpp
@@ -33,7 +33,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputePEAtom::ComputePEAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  energy(NULL)
 {
   if (narg < 3) error->all(FLERR,"Illegal compute pe/atom command");
 
@@ -68,7 +69,6 @@ ComputePEAtom::ComputePEAtom(LAMMPS *lmp, int narg, char **arg) :
   }
 
   nmax = 0;
-  energy = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_pressure.cpp
+++ b/src/compute_pressure.cpp
@@ -34,7 +34,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  vptr(NULL), id_temp(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute pressure command");
   if (igroup) error->all(FLERR,"Compute pressure must use group all");

--- a/src/compute_property_atom.cpp
+++ b/src/compute_property_atom.cpp
@@ -32,7 +32,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputePropertyAtom::ComputePropertyAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  index(NULL), vector(NULL), array(NULL), pack_choice(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute property/atom command");
 
@@ -352,8 +353,6 @@ ComputePropertyAtom::ComputePropertyAtom(LAMMPS *lmp, int narg, char **arg) :
   }
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_property_chunk.cpp
+++ b/src/compute_property_chunk.cpp
@@ -25,7 +25,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputePropertyChunk::ComputePropertyChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), count_one(NULL), count_all(NULL)
 {
   if (narg < 5) error->all(FLERR,"Illegal compute property/chunk command");
 
@@ -78,9 +79,6 @@ ComputePropertyChunk::ComputePropertyChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  vector = NULL;
-  array = NULL;
-  count_one = count_all = NULL;
   allocate();
 
   if (nvalues == 1) {

--- a/src/compute_property_local.cpp
+++ b/src/compute_property_local.cpp
@@ -34,7 +34,8 @@ enum{TYPE,RADIUS};
 /* ---------------------------------------------------------------------- */
 
 ComputePropertyLocal::ComputePropertyLocal(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  vector(NULL), array(NULL), indices(NULL), pack_choice(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute property/local command");
 
@@ -253,9 +254,6 @@ ComputePropertyLocal::ComputePropertyLocal(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Compute property/local requires atom attribute radius");
 
   nmax = 0;
-  vector = NULL;
-  array = NULL;
-  indices = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_rdf.cpp
+++ b/src/compute_rdf.cpp
@@ -38,7 +38,9 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 ComputeRDF::ComputeRDF(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  rdfpair(NULL), nrdfpair(NULL), ilo(NULL), ihi(NULL), jlo(NULL), jhi(NULL),
+  hist(NULL), histall(NULL), typecount(NULL), icount(NULL), jcount(NULL), duplicates(NULL)
 {
   if (narg < 4 || (narg-4) % 2) error->all(FLERR,"Illegal compute rdf command");
 

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -43,7 +43,9 @@ enum{PERATOM,LOCAL};
 /* ---------------------------------------------------------------------- */
 
 ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  nvalues(0), which(NULL), argindex(NULL), flavor(NULL), value2index(NULL), ids(NULL),
+  onevec(NULL), replace(NULL), indices(NULL), owner(NULL), idregion(NULL), varatom(NULL)
 {
   int iarg = 0;
   if (strcmp(style,"reduce") == 0) {

--- a/src/compute_slice.cpp
+++ b/src/compute_slice.cpp
@@ -34,7 +34,8 @@ enum{COMPUTE,FIX,VARIABLE};
 /* ---------------------------------------------------------------------- */
 
 ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  nvalues(0), which(NULL), argindex(NULL), value2index(NULL), ids(NULL)
 {
   if (narg < 7) error->all(FLERR,"Illegal compute slice command");
 

--- a/src/compute_stress_atom.cpp
+++ b/src/compute_stress_atom.cpp
@@ -36,7 +36,8 @@ enum{NOBIAS,BIAS};
 /* ---------------------------------------------------------------------- */
 
 ComputeStressAtom::ComputeStressAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_temp(NULL), stress(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute stress/atom command");
 
@@ -98,7 +99,6 @@ ComputeStressAtom::ComputeStressAtom(LAMMPS *lmp, int narg, char **arg) :
   }
 
   nmax = 0;
-  stress = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_temp_chunk.cpp
+++ b/src/compute_temp_chunk.cpp
@@ -29,7 +29,9 @@ enum{TEMP,KECOM,INTERNAL};
 /* ---------------------------------------------------------------------- */
 
 ComputeTempChunk::ComputeTempChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  which(NULL), idchunk(NULL), id_bias(NULL), sum(NULL), sumall(NULL), count(NULL), 
+  countall(NULL), massproc(NULL), masstotal(NULL), vcm(NULL), vcmall(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute temp/chunk command");
 
@@ -129,12 +131,7 @@ ComputeTempChunk::ComputeTempChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  sum = sumall = NULL;
-  count = countall = NULL;
-  massproc = masstotal = NULL;
-  vcm = vcmall = NULL;
-  array = NULL;
-
+  
   if (nvalues)  {
     array_flag = 1;
     size_array_cols = nvalues;

--- a/src/compute_temp_profile.cpp
+++ b/src/compute_temp_profile.cpp
@@ -31,7 +31,8 @@ enum{TENSOR,BIN};
 /* ---------------------------------------------------------------------- */
 
 ComputeTempProfile::ComputeTempProfile(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  bin(NULL), vbin(NULL), binave(NULL), tbin(NULL), tbinall(NULL)
 {
   if (narg < 7) error->all(FLERR,"Illegal compute temp/profile command");
 
@@ -138,7 +139,6 @@ ComputeTempProfile::ComputeTempProfile(LAMMPS *lmp, int narg, char **arg) :
   }
 
   maxatom = 0;
-  bin = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_temp_region.cpp
+++ b/src/compute_temp_region.cpp
@@ -28,7 +28,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeTempRegion::ComputeTempRegion(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idregion(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute temp/region command");
 

--- a/src/compute_temp_sphere.cpp
+++ b/src/compute_temp_sphere.cpp
@@ -33,7 +33,8 @@ enum{ROTATE,ALL};
 /* ---------------------------------------------------------------------- */
 
 ComputeTempSphere::ComputeTempSphere(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_bias(NULL)
 {
   if (narg < 3) error->all(FLERR,"Illegal compute temp/sphere command");
 
@@ -44,7 +45,6 @@ ComputeTempSphere::ComputeTempSphere(LAMMPS *lmp, int narg, char **arg) :
   tempflag = 1;
 
   tempbias = 0;
-  id_bias = NULL;
   mode = ALL;
 
   int iarg = 3;

--- a/src/compute_torque_chunk.cpp
+++ b/src/compute_torque_chunk.cpp
@@ -26,7 +26,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeTorqueChunk::ComputeTorqueChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), torque(NULL), torqueall(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute torque/chunk command");
 
@@ -48,9 +49,6 @@ ComputeTorqueChunk::ComputeTorqueChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  com = comall = NULL;
-  torque = torqueall = NULL;
   allocate();
 }
 

--- a/src/compute_vacf.cpp
+++ b/src/compute_vacf.cpp
@@ -25,7 +25,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ComputeVACF::ComputeVACF(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  id_fix(NULL)
 {
   if (narg < 3) error->all(FLERR,"Illegal compute vacf command");
 

--- a/src/compute_vcm_chunk.cpp
+++ b/src/compute_vcm_chunk.cpp
@@ -28,7 +28,8 @@ enum{ONCE,NFREQ,EVERY};
 /* ---------------------------------------------------------------------- */
 
 ComputeVCMChunk::ComputeVCMChunk(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+  Compute(lmp, narg, arg),
+  idchunk(NULL), massproc(NULL), masstotal(NULL), vcm(NULL), vcmall(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute vcm/chunk command");
 
@@ -50,8 +51,6 @@ ComputeVCMChunk::ComputeVCMChunk(LAMMPS *lmp, int narg, char **arg) :
 
   nchunk = 1;
   maxchunk = 0;
-  massproc = masstotal = NULL;
-  vcm = vcmall = NULL;
   allocate();
 
   firstflag = massneed = 1;


### PR DESCRIPTION
From Anders Hafreager

This addresses part of the issue described in https://github.com/lammps/lammps/issues/143
Both Anders' Atomify software and Richard's expanded python wrapper need to be able to recover from errors during argument parsing of various commands. Since those both load the LAMMPS shared library and are not running LAMMPS through a pipe, two sets of changes to LAMMPS are required:
- The state of pointers in various styles, especially computes and fixes needs to be consistent, i.e. all pointers reset to NULL, so that the destructor doesn't try to free them, when they become invalid. This pull request addresses a first batch of required changes.
- The Error class must not call exit() or MPI_Abort() but rather throw a suitable exception, which is then caught in main.cpp and library.cpp. See pull request #4 for changes addressing this.
