### PR TITLE
Small update for USER-MANIFOLD docs.

### DIFF
--- a/doc/src/fix_nve_manifold_rattle.txt
+++ b/doc/src/fix_nve_manifold_rattle.txt
@@ -76,10 +76,6 @@ This fix is part of the USER-MANIFOLD package. It is only enabled if LAMMPS
 was built with that package. See the "Making LAMMPS"_Section_start.html#start_3
 section for more info.
 
-Only use this with {min_style hftn} or {min_style quickmin}. If not, the constraints
-will not be satisfied very well at all. A warning is generated if the {min_style} is
-incompatible but no error.
-
 :line
 
 [Related commands:]
@@ -94,7 +90,7 @@ incompatible but no error.
 [(Andersen)] Andersen, J. Comp. Phys. 52, 24, (1983).
 
 :link(Paquay)
-[(Paquay)] Paquay and Kusters, Biophys. J., 110, ???, (2016), to be published,
+[(Paquay)] Paquay and Kusters, Biophys. J., 110, 6, (2016).
 preprint available at "arXiv:1411.3019"_http://arxiv.org/abs/1411.3019/.
 
 

--- a/doc/src/fix_nvt_manifold_rattle.txt
+++ b/doc/src/fix_nvt_manifold_rattle.txt
@@ -62,10 +62,6 @@ This fix is part of the USER-MANIFOLD package. It is only enabled if LAMMPS
 was built with that package. See the "Making LAMMPS"_Section_start.html#start_3
 section for more info.
 
-Only use this with {min_style hftn} or {min_style quickmin}. If not, the constraints
-will not be satisfied very well at all. A warning is generated if the {min_style} is
-incompatible but no error.
-
 :line
 
 
@@ -80,6 +76,6 @@ incompatible but no error.
 [(Andersen)] Andersen, J. Comp. Phys. 52, 24, (1983).
 
 :link(Paquay)
-[(Paquay)] Paquay and Kusters, Biophys. J., 110, ???, (2016), to be published,
+[(Paquay)] Paquay and Kusters, Biophys. J., 110, 6, (2016).
 preprint available at "arXiv:1411.3019"_http://arxiv.org/abs/1411.3019/.
 


### PR DESCRIPTION
This updates the journal with volume and issue, removes text that only belongs to fix_manifoldforce and not fix_nv*_manifold_rattle.
