### PR TITLE
Remove sha1sum dependency for doc generation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,5 @@
 # Makefile for LAMMPS documentation
-SHA1          = $(shell echo $USER-$PWD | sha1sum | cut -f1 -d" ")
+SHA1          = $(shell echo $USER-$PWD | python utils/sha1sum.py)
 BUILDDIR      = /tmp/lammps-docs-$(SHA1)
 RSTDIR        = $(BUILDDIR)/rst
 VENV          = $(BUILDDIR)/docenv

--- a/doc/utils/sha1sum.py
+++ b/doc/utils/sha1sum.py
@@ -1,0 +1,7 @@
+#!/bin/env python
+# simple utility which reimplements sha1sum using Python
+import hashlib
+import sys
+s = hashlib.sha1()
+s.update(sys.stdin.read().encode())
+print(s.hexdigest())


### PR DESCRIPTION
On MacOS X there is no sha1sum. So to simplify doc generation on those systems
use a Python script instead to generate a unique string from the repository
path.
