### PR TITLE
Remove sha1sum dependency for doc generation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,5 @@
 # Makefile for LAMMPS documentation
-SHA1          = $(shell echo $USER-$PWD | sha1sum | cut -f1 -d" ")
+SHA1          = $(shell echo $USER-$PWD | python utils/sha1sum.py)
 BUILDDIR      = /tmp/lammps-docs-$(SHA1)
 RSTDIR        = $(BUILDDIR)/rst
 VENV          = $(BUILDDIR)/docenv

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,18 +15,28 @@ make clean-all    # remove entire build folder and any cached data
 ## Installing prerequisites
 
 To run the documention build toolchain Python 3 and virtualenv have to be
-installed. The following are instructions for common Linux distributions:
+installed. Here are instructions for common setups:
 
-### virtualenv
-
-#### Ubuntu
+### Ubuntu
 
 ```bash
 sudo apt-get install python-virtualenv
 ```
 
-#### Fedora
+### Fedora
 
 ```
 sudo yum install python-virtualenv
 ```
+
+### MacOS X
+
+## Python 3
+
+Download the latest Python 3 MacOS X package from https://www.python.org and install it.
+This will install both Python 3 and pip3.
+
+## virtualenv
+
+Once Python 3 is installed, open a Terminal and type `pip3 install virtualenv`. This will
+install virtualenv from the Python Package Index.

--- a/doc/utils/sha1sum.py
+++ b/doc/utils/sha1sum.py
@@ -1,0 +1,7 @@
+#!/bin/env python
+# simple utility which reimplements sha1sum using Python
+import hashlib
+import sys
+s = hashlib.sha1()
+s.update(sys.stdin.read().encode())
+print(s.hexdigest())


### PR DESCRIPTION
On MacOS X there is no sha1sum. So to simplify doc generation on those systems
use a Python script instead to generate a unique string from the repository
path.
