### PR TITLE
Disable custom locale and grep options in shell scripts

### DIFF
--- a/src/COMPRESS/Install.sh
+++ b/src/COMPRESS/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/CORESHELL/Install.sh
+++ b/src/CORESHELL/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/Depend.sh
+++ b/src/Depend.sh
@@ -1,6 +1,10 @@
 # Depend.sh = Install/unInstall files due to package dependencies
 # this script is invoked after any package is installed/uninstalled
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # all parent/child package dependencies should be listed below
 # parent package = has files that files in another package derive from
 # child package = has files that derive from files in another package

--- a/src/GPU/Install.sh
+++ b/src/GPU/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/Install.sh
+++ b/src/Install.sh
@@ -7,6 +7,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/KIM/Install.sh
+++ b/src/KIM/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/MEAM/Install.sh
+++ b/src/MEAM/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/MPIIO/Install.sh
+++ b/src/MPIIO/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/Make.sh
+++ b/src/Make.sh
@@ -5,6 +5,12 @@
 #         sh Make.sh Makefile.shlib
 #         sh Make.sh Makefile.list
 
+# turn off enforced customizations
+GREP_OPTIONS=
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL GREP_OPTIONS
+
 # function to create one style_*.h file
 # must whack *.d files that depend on style_*.h file,
 # else Make will not recreate them

--- a/src/OPT/Install.sh
+++ b/src/OPT/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/POEMS/Install.sh
+++ b/src/POEMS/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/PYTHON/Install.sh
+++ b/src/PYTHON/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/Package.sh
+++ b/src/Package.sh
@@ -1,6 +1,10 @@
 # Package.sh = package management, called from Makefile
 # Syntax: sh Package.sh DIR status/update/overwrite/diff
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # package is already installed if any package *.cpp or *.h file is in src
 # else not installed
 

--- a/src/REAX/Install.sh
+++ b/src/REAX/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/USER-ATC/Install.sh
+++ b/src/USER-ATC/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/USER-AWPMD/Install.sh
+++ b/src/USER-AWPMD/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/USER-CG-CMM/Install.sh
+++ b/src/USER-CG-CMM/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/USER-COLVARS/Install.sh
+++ b/src/USER-COLVARS/Install.sh
@@ -5,6 +5,10 @@ mode=$1
 
 # arg1 = file, arg2 = file it depends on
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/USER-FEP/Install.sh
+++ b/src/USER-FEP/Install.sh
@@ -1,11 +1,11 @@
 # Install/unInstall package files in LAMMPS
 # mode = 0/1/2 for uninstall/install/update
 
-# this is default Install.sh for all packages
-# if package has an auxiliary library or a file with a dependency,
-# then package dir has its own customized Install.sh
-
 mode=$1
+
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
 
 # arg1 = file, arg2 = file it depends on
 

--- a/src/USER-H5MD/Install.sh
+++ b/src/USER-H5MD/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-INTEL/Install.sh
+++ b/src/USER-INTEL/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-MISC/Install.sh
+++ b/src/USER-MISC/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-MOLFILE/Install.sh
+++ b/src/USER-MOLFILE/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-OMP/Install.sh
+++ b/src/USER-OMP/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-PHONON/Install.sh
+++ b/src/USER-PHONON/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-QMMM/Install.sh
+++ b/src/USER-QMMM/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-QUIP/Install.sh
+++ b/src/USER-QUIP/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-SMD/Install.sh
+++ b/src/USER-SMD/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/USER-VTK/Install.sh
+++ b/src/USER-VTK/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/VORONOI/Install.sh
+++ b/src/VORONOI/Install.sh
@@ -3,6 +3,10 @@
 
 mode=$1
 
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
 # arg1 = file, arg2 = file it depends on
 
 action () {


### PR DESCRIPTION
enforce C locale in build related shell scripts and also turn off global grep options enforced via use of GREP_OPTIONS environment variable. This should improve closer compliance to POSIX behavior and thus limit the chance of customized personal settings to affect the scripts.
