### PR TITLE
corrections for various compute something/chunk examples

### DIFF
--- a/doc/html/Section_howto.html
+++ b/doc/html/Section_howto.html
@@ -2333,7 +2333,7 @@ velocity:</p>
 </ol>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">com</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <ol class="arabic simple" start="4">

--- a/doc/html/compute_angmom_chunk.html
+++ b/doc/html/compute_angmom_chunk.html
@@ -180,7 +180,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">angmom</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_com_chunk.html
+++ b/doc/html/compute_com_chunk.html
@@ -178,7 +178,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">com</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_dipole_chunk.html
+++ b/doc/html/compute_dipole_chunk.html
@@ -183,7 +183,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">dipole</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_inertia_chunk.html
+++ b/doc/html/compute_inertia_chunk.html
@@ -179,7 +179,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">inertia</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_msd_chunk.html
+++ b/doc/html/compute_msd_chunk.html
@@ -215,7 +215,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">com</span><span class="o">/</span><span class="n">msd</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_omega_chunk.html
+++ b/doc/html/compute_omega_chunk.html
@@ -178,11 +178,11 @@ how they are set for each atom.  You can reset the image flags
 <p>The simplest way to output the results of the compute omega/chunk
 calculation to a file is to use the <a class="reference internal" href="fix_ave_time.html"><span class="doc">fix ave/time</span></a>
 command, for example:</p>
-<pre class="literal-block">
-compute cc1 all chunk/atom molecule
-compute myChunk all omega/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk<strong>*</strong> file tmp.out mode vector
-</pre>
+<div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
+<span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">omega</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+</pre></div>
+</div>
 <p><strong>Output info:</strong></p>
 <p>This compute calculates a global array where the number of rows = the
 number of chunks <em>Nchunk</em> as calculated by the specified <a class="reference internal" href="compute_chunk_atom.html"><span class="doc">compute chunk/atom</span></a> command.  The number of columns =

--- a/doc/html/compute_property_chunk.html
+++ b/doc/html/compute_property_chunk.html
@@ -193,9 +193,9 @@ will be in unitless reduced units (0-1).</p>
 calculation to a file is to use the <a class="reference internal" href="fix_ave_time.html"><span class="doc">fix ave/time</span></a>
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
-<span class="n">compute</span> <span class="n">myChunk1</span> <span class="nb">all</span> <span class="nb">property</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
+<span class="n">compute</span> <span class="n">myChunk1</span> <span class="nb">all</span> <span class="nb">property</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span> <span class="n">count</span>
 <span class="n">compute</span> <span class="n">myChunk2</span> <span class="nb">all</span> <span class="n">com</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk1</span> <span class="n">c_myChunk2</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk1</span> <span class="n">c_myChunk2</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_torque_chunk.html
+++ b/doc/html/compute_torque_chunk.html
@@ -179,7 +179,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">torque</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/html/compute_vcm_chunk.html
+++ b/doc/html/compute_vcm_chunk.html
@@ -169,7 +169,7 @@ calculation to a file is to use the <a class="reference internal" href="fix_ave_
 command, for example:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">cc1</span> <span class="nb">all</span> <span class="n">chunk</span><span class="o">/</span><span class="n">atom</span> <span class="n">molecule</span>
 <span class="n">compute</span> <span class="n">myChunk</span> <span class="nb">all</span> <span class="n">vcm</span><span class="o">/</span><span class="n">chunk</span> <span class="n">cc1</span>
-<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
+<span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">time</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">c_myChunk</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">out</span> <span class="n">mode</span> <span class="n">vector</span>
 </pre></div>
 </div>
 <p><strong>Output info:</strong></p>

--- a/doc/src/Section_howto.txt
+++ b/doc/src/Section_howto.txt
@@ -2297,7 +2297,7 @@ fix 1 all ave/chunk 100 10 1000 cc1 temp bias vbias file tmp.out :pre
 
 compute cc1 all chunk/atom molecule
 compute myChunk all com/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 (4) Total force on each molecule and ave/max across all molecules:
 

--- a/doc/src/compute_angmom_chunk.txt
+++ b/doc/src/compute_angmom_chunk.txt
@@ -64,7 +64,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all angmom/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_com_chunk.txt
+++ b/doc/src/compute_com_chunk.txt
@@ -62,7 +62,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all com/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_dipole_chunk.txt
+++ b/doc/src/compute_dipole_chunk.txt
@@ -67,7 +67,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all dipole/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_inertia_chunk.txt
+++ b/doc/src/compute_inertia_chunk.txt
@@ -63,7 +63,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all inertia/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_msd_chunk.txt
+++ b/doc/src/compute_msd_chunk.txt
@@ -97,7 +97,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all com/msd cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_omega_chunk.txt
+++ b/doc/src/compute_omega_chunk.txt
@@ -64,7 +64,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all omega/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk[*] file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_property_chunk.txt
+++ b/doc/src/compute_property_chunk.txt
@@ -86,9 +86,9 @@ calculation to a file is to use the "fix ave/time"_fix_ave_time.html
 command, for example:
 
 compute cc1 all chunk/atom molecule
-compute myChunk1 all property/chunk cc1
+compute myChunk1 all property/chunk cc1 count
 compute myChunk2 all com/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk1 c_myChunk2 file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk1 c_myChunk2\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_torque_chunk.txt
+++ b/doc/src/compute_torque_chunk.txt
@@ -63,7 +63,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all torque/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 

--- a/doc/src/compute_vcm_chunk.txt
+++ b/doc/src/compute_vcm_chunk.txt
@@ -54,7 +54,7 @@ command, for example:
 
 compute cc1 all chunk/atom molecule
 compute myChunk all vcm/chunk cc1
-fix 1 all ave/time 100 1 100 c_myChunk file tmp.out mode vector :pre
+fix 1 all ave/time 100 1 100 c_myChunk\[*\] file tmp.out mode vector :pre
 
 [Output info:]
 


### PR DESCRIPTION
many examples for using fix ave/time on compute <something>/chunk were not working (anymore?).
this corrects the documentation accordingly.

Updated the pull request to include generated html
