### PR TITLE
Clean up incorrect link targets in documentation

### DIFF
--- a/doc/html/Section_howto.html
+++ b/doc/html/Section_howto.html
@@ -1086,7 +1086,7 @@ the sheared fluid and integrate the SLLOD equations of motion for the
 system.  Fix nvt/sllod uses <a class="reference internal" href="compute_temp_deform.html"><span class="doc">compute temp/deform</span></a> to compute a thermal temperature
 by subtracting out the streaming velocity of the shearing atoms.  The
 velocity profile or other properties of the fluid can be monitored via
-the <span class="xref doc">fix ave/spatial</span> command.</p>
+the <a class="reference internal" href="fix_ave_chunk.html"><span class="doc">fix ave/chunk</span></a> command.</p>
 <p>As discussed in the previous section on non-orthogonal simulation
 boxes, the amount of tilt or skew that can be applied is limited by
 LAMMPS for computational efficiency to be 1/2 of the parallel box
@@ -2011,13 +2011,13 @@ on each of two regions to add/subtract specified amounts of energy to
 both regions.  In both cases, the resulting temperatures of the two
 regions can be monitored with the &#8220;compute temp/region&#8221; command and
 the temperature profile of the intermediate region can be monitored
-with the <span class="xref doc">fix ave/spatial</span> and <a class="reference internal" href="compute_ke_atom.html"><span class="doc">compute ke/atom</span></a> commands.</p>
+with the <a class="reference internal" href="fix_ave_chunk.html"><span class="doc">fix ave/chunk</span></a> and <a class="reference internal" href="compute_ke_atom.html"><span class="doc">compute ke/atom</span></a> commands.</p>
 <p>The third method is to perform a reverse non-equilibrium MD simulation
 using the <a class="reference internal" href="fix_thermal_conductivity.html"><span class="doc">fix thermal/conductivity</span></a>
 command which implements the rNEMD algorithm of Muller-Plathe.
 Kinetic energy is swapped between atoms in two different layers of the
 simulation box.  This induces a temperature gradient between the two
-layers which can be monitored with the <span class="xref doc">fix ave/spatial</span> and <a class="reference internal" href="compute_ke_atom.html"><span class="doc">compute ke/atom</span></a> commands.  The fix tallies the
+layers which can be monitored with the <a class="reference internal" href="fix_ave_chunk.html"><span class="doc">fix ave/chunk</span></a> and <a class="reference internal" href="compute_ke_atom.html"><span class="doc">compute ke/atom</span></a> commands.  The fix tallies the
 cumulative energy transfer that it performs.  See the <a class="reference internal" href="fix_thermal_conductivity.html"><span class="doc">fix thermal/conductivity</span></a> command for
 details.</p>
 <p>The fourth method is based on the Green-Kubo (GK) formula which
@@ -2060,7 +2060,7 @@ used to shear the fluid in between them, again with some kind of
 thermostat that modifies only the thermal (non-shearing) components of
 velocity to prevent the fluid from heating up.</p>
 <p>In both cases, the velocity profile setup in the fluid by this
-procedure can be monitored by the <span class="xref doc">fix ave/spatial</span> command, which determines
+procedure can be monitored by the <a class="reference internal" href="fix_ave_chunk.html"><span class="doc">fix ave/chunk</span></a> command, which determines
 grad(Vstream) in the equation above.  E.g. the derivative in the
 y-direction of the Vx component of fluid motion or grad(Vstream) =
 dVx/dy.  The Pxy off-diagonal component of the pressure or stress
@@ -2073,7 +2073,7 @@ using the <a class="reference internal" href="fix_viscosity.html"><span class="d
 the rNEMD algorithm of Muller-Plathe.  Momentum in one dimension is
 swapped between atoms in two different layers of the simulation box in
 a different dimension.  This induces a velocity gradient which can be
-monitored with the <span class="xref doc">fix ave/spatial</span> command.
+monitored with the <a class="reference internal" href="fix_ave_chunk.html"><span class="doc">fix ave/chunk</span></a> command.
 The fix tallies the cummulative momentum transfer that it performs.
 See the <a class="reference internal" href="fix_viscosity.html"><span class="doc">fix viscosity</span></a> command for details.</p>
 <p>The fourth method is based on the Green-Kubo (GK) formula which

--- a/doc/html/Section_intro.html
+++ b/doc/html/Section_intro.html
@@ -391,7 +391,7 @@ molecular dynamics options:</p>
 <li>coupled rigid body integration via the <a class="reference internal" href="fix_poems.html"><span class="doc">POEMS</span></a> library</li>
 <li><a class="reference internal" href="fix_qmmm.html"><span class="doc">QM/MM coupling</span></a></li>
 <li><a class="reference internal" href="fix_ipi.html"><span class="doc">path-integral molecular dynamics (PIMD)</span></a> and <a class="reference internal" href="fix_pimd.html"><span class="doc">this as well</span></a></li>
-<li>Monte Carlo via <a class="reference internal" href="fix_gcmc.html"><span class="doc">GCMC</span></a> and <a class="reference internal" href="fix_tfmc.html"><span class="doc">tfMC</span></a> and <span class="xref doc">atom swapping</span></li>
+<li>Monte Carlo via <a class="reference internal" href="fix_gcmc.html"><span class="doc">GCMC</span></a> and <a class="reference internal" href="fix_tfmc.html"><span class="doc">tfMC</span></a> <a class="reference internal" href="fix_atom_swap.html"><span class="doc">atom swapping</span></a> and <a class="reference internal" href="fix_bond_swap.html"><span class="doc">bond swapping</span></a></li>
 <li><a class="reference internal" href="pair_dsmc.html"><span class="doc">Direct Simulation Monte Carlo</span></a> for low-density fluids</li>
 <li><a class="reference internal" href="pair_peri.html"><span class="doc">Peridynamics mesoscale modeling</span></a></li>
 <li><a class="reference internal" href="fix_lb_fluid.html"><span class="doc">Lattice Boltzmann fluid</span></a></li>

--- a/doc/html/Section_packages.html
+++ b/doc/html/Section_packages.html
@@ -1224,7 +1224,7 @@ styles which implement different materials models.</p>
 <p>Supporting info:
 <a class="reference external" href="PDF/PDLammps_overview.pdf">doc/PDF/PDLammps_overview.pdf</a>,
 <a class="reference external" href="PDF/PDLammps_EPS.pdf">doc/PDF/PDLammps_EPS.pdf</a>,
-<a class="reference external" href="PDF/PDLammps_VES.pdf">doc/PDF/PDLammps_VES.pdf</a>, <a class="reference internal" href="atom_style.html"><span class="doc">atom_style peri</span></a>, <span class="xref doc">compute damage</span>,
+<a class="reference external" href="PDF/PDLammps_VES.pdf">doc/PDF/PDLammps_VES.pdf</a>, <a class="reference internal" href="atom_style.html"><span class="doc">atom_style peri</span></a>, <a class="reference internal" href="compute_damage_atom.html"><span class="doc">compute damage/atom</span></a>,
 <a class="reference internal" href="pair_peri.html"><span class="doc">pair_style peri/pmb</span></a>, examples/peri</p>
 <hr class="docutils" />
 </div>
@@ -1272,9 +1272,8 @@ one step.  Type &#8220;python src/Make.py -h -poems&#8221; to see the details.</
 <span id="python"></span><h3>4.1.22. PYTHON package</h3>
 <p>Contents: A <a class="reference internal" href="python.html"><span class="doc">python</span></a> command which allow you to execute
 Python code from a LAMMPS input script.  The code can be in a separate
-file or embedded in the input script itself.  See <span class="xref std std-ref">Section python 11.2</span> for an overview of using Python from
-LAMMPS and <a class="reference external" href="Section_python.html&quot;">Section python</a> for other ways to use
-LAMMPS and Python together.</p>
+file or embedded in the input script itself.  See <a class="reference external" href="Section_python.html&quot;">Section python 11.2</a> for an overview of using Python from
+LAMMPS and for other ways to use LAMMPS and Python together.</p>
 <p>Building with the PYTHON package assumes you have a Python shared
 library available on your system, which needs to be a Python 2
 version, 2.6 or later.  Python 3 is not supported.  The build uses the
@@ -1427,7 +1426,7 @@ few large bodies or many small bodies.</p>
 </pre></div>
 </div>
 <p>Supporting info: <a class="reference internal" href="compute_erotate_rigid.html"><span class="doc">compute erotate/rigid</span></a>,
-<a class="reference internal" href="fix_shake.html"><span class="doc">fix shake</span></a>, <span class="xref doc">fix rattle</span>, <a class="reference internal" href="fix_rigid.html"><span class="doc">fix rigid/*</span></a>, examples/ASPHERE, examples/rigid</p>
+<a class="reference internal" href="fix_shake.html"><span class="doc">fix shake</span></a>, <a class="reference internal" href="fix_shake.html"><span class="doc">fix rattle</span></a>, <a class="reference internal" href="fix_rigid.html"><span class="doc">fix rigid/*</span></a>, examples/ASPHERE, examples/rigid</p>
 <hr class="docutils" />
 </div>
 <div class="section" id="shock-package">
@@ -1475,8 +1474,8 @@ properties of the potential are also included.</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">Make</span><span class="o">.</span><span class="n">py</span> <span class="o">-</span><span class="n">p</span> <span class="o">^</span><span class="n">snap</span> <span class="o">-</span><span class="n">a</span> <span class="n">machine</span>
 </pre></div>
 </div>
-<p>Supporting info: <a class="reference internal" href="pair_snap.html"><span class="doc">pair snap</span></a>, <a class="reference internal" href="compute_sna_atom.html"><span class="doc">compute sna/atom</span></a>, <span class="xref doc">compute snad/atom</span>,
-<span class="xref doc">compute snav/atom</span>, examples/snap</p>
+<p>Supporting info: <a class="reference internal" href="pair_snap.html"><span class="doc">pair snap</span></a>, <a class="reference internal" href="compute_sna_atom.html"><span class="doc">compute sna/atom</span></a>, <a class="reference internal" href="compute_sna_atom.html"><span class="doc">compute snad/atom</span></a>,
+<a class="reference internal" href="compute_sna_atom.html"><span class="doc">compute snav/atom</span></a>, examples/snap</p>
 <hr class="docutils" />
 </div>
 <div class="section" id="srd-package">
@@ -1900,7 +1899,7 @@ src/Make.py -h -voronoi&#8221; to see the details.</p>
 <tr class="row-odd"><td><a class="reference internal" href="#user-tally"><span class="std std-ref">USER-TALLY</span></a></td>
 <td>Pairwise tallied computes</td>
 <td>Axel Kohlmeyer (Temple U)</td>
-<td><span class="xref doc">compute</span></td>
+<td><a class="reference internal" href="compute_tally.html"><span class="doc">compute XXX/tally</span></a></td>
 <td>USER/tally</td>
 <td><ul class="first last simple">
 <li></li>
@@ -1914,7 +1913,7 @@ src/Make.py -h -voronoi&#8221; to see the details.</p>
 <tr class="row-even"><td><a class="reference internal" href="#user-vtk"><span class="std std-ref">USER-VTK</span></a></td>
 <td>VTK-style dumps</td>
 <td>Berger and Queteschiner (6)</td>
-<td><span class="xref doc">compute custom/vtk</span></td>
+<td><a class="reference internal" href="dump_custom_vtk.html"><span class="doc">compute custom/vtk</span></a></td>
 <td><ul class="first last simple">
 <li></li>
 </ul>
@@ -2004,7 +2003,7 @@ Dynamics.  This package implements an atom, pair, and fix style which
 allows electrons to be treated as explicit particles in an MD
 calculation.  See src/USER-AWPMD/README for more details.</p>
 <p>To build LAMMPS with this package ...</p>
-<p>Supporting info: src/USER-AWPMD/README, <span class="xref doc">fix awpmd/cut</span>, examples/USER/awpmd</p>
+<p>Supporting info: src/USER-AWPMD/README, <a class="reference internal" href="pair_awpmd.html"><span class="doc">fix awpmd/cut</span></a>, examples/USER/awpmd</p>
 <p>Author: Ilya Valuev at the JIHT in Russia (valuev at
 physik.hu-berlin.de).  Contact him directly if you have questions.</p>
 <hr class="docutils" />
@@ -2047,7 +2046,7 @@ have questions.</p>
 calculating x-ray and electron diffraction intensities based on
 kinematic diffraction theory.  See src/USER-DIFFRACTION/README for
 more details.</p>
-<p>Supporting info: <a class="reference internal" href="compute_saed.html"><span class="doc">compute saed</span></a>, <a class="reference internal" href="compute_xrd.html"><span class="doc">compute xrd</span></a>, <a class="reference internal" href="fix_saed_vtk.html"><span class="doc">fix saed.vtk</span></a>,
+<p>Supporting info: <a class="reference internal" href="compute_saed.html"><span class="doc">compute saed</span></a>, <a class="reference internal" href="compute_xrd.html"><span class="doc">compute xrd</span></a>, <a class="reference internal" href="fix_saed_vtk.html"><span class="doc">fix saed/vtk</span></a>,
 examples/USER/diffraction</p>
 <p>Author: Shawn P. Coleman (shawn.p.coleman8.ctr at mail.mil) while at
 the University of Arkansas.  Contact him directly if you have
@@ -2065,11 +2064,13 @@ equations of motion are integrated efficiently through the Shardlow
 splitting algorithm.  See src/USER-DPD/README for more details.</p>
 <p>Supporting info: /src/USER-DPD/README, <a class="reference internal" href="compute_dpd.html"><span class="doc">compute dpd</span></a>
 <a class="reference internal" href="compute_dpd_atom.html"><span class="doc">compute dpd/atom</span></a>
-<a class="reference internal" href="fix_eos_table.html"><span class="doc">fix eos/cv</span></a> <a class="reference internal" href="fix_eos_table.html"><span class="doc">fix eos/table</span></a>
-<a class="reference internal" href="fix_shardlow.html"><span class="doc">fix shardlow</span></a>
-<span class="xref doc">pair_dpd/conservative</span>
-<a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair_dpd/fdt</span></a>
-<a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair_dpd/fdt/energy</span></a>, examples/USER/dpd</p>
+<a class="reference internal" href="fix_eos_table.html"><span class="doc">fix eos/cv</span></a> <a class="reference internal" href="fix_eos_table.html"><span class="doc">fix eos/table</span></a></p>
+<blockquote>
+<div><a class="reference internal" href="fix_eos_table_rx.html"><span class="doc">fix eos/table/rx</span></a> <a class="reference internal" href="fix_shardlow.html"><span class="doc">fix shardlow</span></a></div></blockquote>
+<p><a class="reference internal" href="fix_rx.html"><span class="doc">fix rx</span></a> <a class="reference internal" href="pair_table_rx.html"><span class="doc">pair table/rx</span></a>
+<a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair dpd/fdt</span></a> <a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair dpd/fdt/energy</span></a>
+<a class="reference internal" href="pair_exp6_rx.html"><span class="doc">pair exp6/rx</span></a> <a class="reference internal" href="pair_multi_lucy.html"><span class="doc">pair multi/lucy</span></a>
+<a class="reference internal" href="pair_multi_lucy_rx.html"><span class="doc">pair multi/lucy/rx</span></a>, examples/USER/dpd</p>
 <p>Authors: James Larentzos (ARL) (james.p.larentzos.civ at mail.mil),
 Timothy Mattox (Engility Corp) (Timothy.Mattox at engilitycorp.com)
 and John Brennan (ARL) (john.k.brennan.civ at mail.mil).  Contact them
@@ -2144,7 +2145,7 @@ this package.  Also see src/USER-INTEL/README for more details. See
 the KOKKOS, OPT, and USER-OMP packages, which also have CPU and
 Phi-enabled styles.</p>
 <p>Supporting info: examples/accelerate, src/USER-INTEL/TEST</p>
-<p><span class="xref std std-ref">Section_accelerate</span></p>
+<p><a class="reference internal" href="Section_accelerate.html#acc-3"><span class="std std-ref">Section_accelerate</span></a></p>
 <p>Author: Mike Brown at Intel (michael.w.brown at intel.com).  Contact
 him directly if you have questions.</p>
 <p>For the USER-INTEL package, you have 2 choices when building.  You can
@@ -2261,7 +2262,7 @@ to VMD, support for new file formats can be added to LAMMPS (or VMD or
 other programs that use them) without having to recompile the
 application itself.</p>
 <p>See this doc page to get started:</p>
-<p><span class="xref std std-ref">dump molfile</span></p>
+<p><a class="reference internal" href="dump_molfile.html"><span class="doc">dump molfile</span></a></p>
 <p>The person who created this package is Axel Kohlmeyer at Temple U
 (akohlmey at gmail.com).  Contact him directly if you have questions.</p>
 <hr class="docutils" />
@@ -2273,7 +2274,7 @@ application itself.</p>
 other optimizations of various LAMMPS pair styles, dihedral
 styles, and fix styles.</p>
 <p>See this section of the manual to get started:</p>
-<p><span class="xref std std-ref">Section_accelerate</span></p>
+<p><a class="reference internal" href="Section_accelerate.html#acc-3"><span class="std std-ref">Section_accelerate</span></a></p>
 <p>The person who created this package is Axel Kohlmeyer at Temple U
 (akohlmey at gmail.com).  Contact him directly if you have questions.</p>
 <p>For the USER-OMP package, your Makefile.machine needs additional

--- a/doc/html/Section_start.html
+++ b/doc/html/Section_start.html
@@ -1365,7 +1365,7 @@ supercomputer there may be dozens or 1000s of physical nodes.</p>
 Note that the keywords do not use a leading minus sign.  I.e. the
 keyword is &#8220;t&#8221;, not &#8220;-t&#8221;.  Also note that each of the keywords has a
 default setting.  Example of when to use these options and what
-settings to use on different platforms is given in <span class="xref std std-ref">Section 5.8</span>.</p>
+settings to use on different platforms is given in <a class="reference internal" href="Section_accelerate.html#acc-3"><span class="std std-ref">Section 5.8</span></a>.</p>
 <ul class="simple">
 <li>d or device</li>
 <li>g or gpus</li>

--- a/doc/html/accelerate_kokkos.html
+++ b/doc/html/accelerate_kokkos.html
@@ -351,7 +351,7 @@ used if running with KOKKOS_DEVICES=Pthreads for pthreads.  It is not
 necessary for KOKKOS_DEVICES=OpenMP for OpenMP, because OpenMP
 provides alternative methods via environment variables for binding
 threads to hardware cores.  More info on binding threads to cores is
-given in <span class="xref std std-ref">this section</span>.</p>
+given in <a class="reference internal" href="Section_accelerate.html#acc-3"><span class="std std-ref">this section</span></a>.</p>
 <p>KOKKOS_ARCH=KNC enables compiler switches needed when compling for an
 Intel Phi processor.</p>
 <p>KOKKOS_USE_TPLS=librt enables use of a more accurate timer mechanism

--- a/doc/html/compute_damage_atom.html
+++ b/doc/html/compute_damage_atom.html
@@ -170,7 +170,8 @@ LAMMPS was built with that package.  See the <a class="reference internal" href=
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><span class="xref doc">compute dilatation</span>, <span class="xref doc">compute plasticity</span></p>
+<p><a class="reference internal" href="compute_dilatation_atom.html"><span class="doc">compute dilatation/atom</span></a>,
+<a class="reference internal" href="compute_plasticity_atom.html"><span class="doc">compute plasticity/atom</span></a></p>
 <p><strong>Default:</strong> none</p>
 </div>
 </div>

--- a/doc/html/compute_dilatation_atom.html
+++ b/doc/html/compute_dilatation_atom.html
@@ -172,7 +172,8 @@ LAMMPS was built with that package.  See the <a class="reference internal" href=
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><span class="xref doc">compute damage</span>, <span class="xref doc">compute plasticity</span></p>
+<p><a class="reference internal" href="compute_damage_atom.html"><span class="doc">compute damage/atom</span></a>,
+<a class="reference internal" href="compute_plasticity_atom.html"><span class="doc">compute plasticity/atom</span></a></p>
 <p><strong>Default:</strong> none</p>
 </div>
 </div>

--- a/doc/html/compute_erotate_rigid.html
+++ b/doc/html/compute_erotate_rigid.html
@@ -172,7 +172,7 @@ LAMMPS was built with that package.  See the <a class="reference internal" href=
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><span class="xref doc">compute ke/rigid</span></p>
+<p><a class="reference internal" href="compute_ke_rigid.html"><span class="doc">compute ke/rigid</span></a></p>
 <p><strong>Default:</strong> none</p>
 </div>
 </div>

--- a/doc/html/compute_plasticity_atom.html
+++ b/doc/html/compute_plasticity_atom.html
@@ -168,7 +168,8 @@ LAMMPS was built with that package.  See the <a class="reference internal" href=
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><span class="xref doc">compute damage</span>, <span class="xref doc">compute dilatation</span></p>
+<p><a class="reference internal" href="compute_damage_atom.html"><span class="doc">compute damage/atom</span></a>,
+<a class="reference internal" href="compute_dilatation_atom.html"><span class="doc">compute dilatation/atom</span></a></p>
 <p><strong>Default:</strong> none</p>
 <hr class="docutils" />
 <p id="mitchell"><strong>(Mitchell)</strong> Mitchell, &#8220;A non-local, ordinary-state-based

--- a/doc/html/compute_reduce.html
+++ b/doc/html/compute_reduce.html
@@ -220,7 +220,7 @@ asterisk means all indices from n to N (inclusive).  A middle asterisk
 means all indices from m to n (inclusive).</p>
 <p>Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 compute reduce commands are
-equivalent, since the <span class="xref doc">compute stress/atom</span>
+equivalent, since the <a class="reference internal" href="compute_stress_atom.html"><span class="doc">compute stress/atom</span></a>
 command creates a per-atom array with 6 columns:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">myPress</span> <span class="nb">all</span> <span class="n">stress</span><span class="o">/</span><span class="n">atom</span> <span class="n">NULL</span>
 <span class="n">compute</span> <span class="mi">2</span> <span class="nb">all</span> <span class="n">reduce</span> <span class="nb">min</span> <span class="n">myPress</span><span class="p">[</span><span class="o">*</span><span class="p">]</span>

--- a/doc/html/compute_temp_deform_eff.html
+++ b/doc/html/compute_temp_deform_eff.html
@@ -149,11 +149,11 @@ nuclei and electrons in the <a class="reference internal" href="pair_eff.html"><
 model, after subtracting out a streaming velocity induced by the
 simulation box changing size and/or shape, for example in a
 non-equilibrium MD (NEMD) simulation.  The size/shape change is
-induced by use of the <span class="xref doc">fix deform/eff</span> command.  A
+induced by use of the <a class="reference internal" href="fix_deform.html"><span class="doc">fix deform</span></a> command.  A
 compute of this style is created by the <a class="reference internal" href="fix_nvt_sllod_eff.html"><span class="doc">fix nvt/sllod/eff</span></a> command to compute the thermal
 temperature of atoms for thermostatting purposes.  A compute of this
 style can also be used by any command that computes a temperature,
-e.g. <a class="reference internal" href="thermo_modify.html"><span class="doc">thermo_modify</span></a>, <a class="reference internal" href="fix_nh.html"><span class="doc">fix npt/eff</span></a>,
+e.g. <a class="reference internal" href="thermo_modify.html"><span class="doc">thermo_modify</span></a>, <a class="reference internal" href="fix_nh_eff.html"><span class="doc">fix npt/eff</span></a>,
 etc.</p>
 <p>The calculation performed by this compute is exactly like that
 described by the <a class="reference internal" href="compute_temp_deform.html"><span class="doc">compute temp/deform</span></a>
@@ -180,7 +180,8 @@ LAMMPS was built with that package.  See the <a class="reference internal" href=
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><a class="reference internal" href="compute_temp_ramp.html"><span class="doc">compute temp/ramp</span></a>, <span class="xref doc">fix deform/eff</span>, <a class="reference internal" href="fix_nvt_sllod_eff.html"><span class="doc">fix nvt/sllod/eff</span></a></p>
+<p><a class="reference internal" href="compute_temp_ramp.html"><span class="doc">compute temp/ramp</span></a>, <a class="reference internal" href="fix_deform.html"><span class="doc">fix deform</span></a>,
+<a class="reference internal" href="fix_nvt_sllod_eff.html"><span class="doc">fix nvt/sllod/eff</span></a></p>
 <p><strong>Default:</strong> none</p>
 </div>
 </div>

--- a/doc/html/compute_temp_eff.html
+++ b/doc/html/compute_temp_eff.html
@@ -148,7 +148,7 @@
 <p>Define a computation that calculates the temperature of a group of
 nuclei and electrons in the <a class="reference internal" href="pair_eff.html"><span class="doc">electron force field</span></a>
 model.  A compute of this style can be used by commands that compute a
-temperature, e.g. <a class="reference internal" href="thermo_modify.html"><span class="doc">thermo_modify</span></a>, <span class="xref doc">fix npt/eff</span>, etc.</p>
+temperature, e.g. <a class="reference internal" href="thermo_modify.html"><span class="doc">thermo_modify</span></a>, <a class="reference internal" href="fix_nh_eff.html"><span class="doc">fix npt/eff</span></a>, etc.</p>
 <p>The temperature is calculated by the formula KE = dim/2 N k T, where
 KE = total kinetic energy of the group of atoms (sum of 1/2 m v^2 for
 nuclei and sum of 1/2 (m v^2 + 3/4 m s^2) for electrons, where s

--- a/doc/html/dihedral_table.html
+++ b/doc/html/dihedral_table.html
@@ -301,7 +301,7 @@ more instructions on how to use the accelerated styles effectively.</p>
 <div class="section" id="restrictions">
 <h2>Restrictions</h2>
 <p>This dihedral style can only be used if LAMMPS was built with the
-USER-MISC package.  See the <span class="xref std std-ref">Making LAMMPS</span>
+USER-MISC package.  See the <a class="reference internal" href="Section_start.html#start-3"><span class="std std-ref">Making LAMMPS</span></a>
 section for more info on packages.</p>
 </div>
 <div class="section" id="related-commands">

--- a/doc/html/dump.html
+++ b/doc/html/dump.html
@@ -550,7 +550,7 @@ indices from n to N (inclusive).  A middle asterisk means all indices
 from m to n (inclusive).</p>
 <p>Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 dump commands are
-equivalent, since the <span class="xref doc">compute stress/atom</span>
+equivalent, since the <a class="reference internal" href="compute_stress_atom.html"><span class="doc">compute stress/atom</span></a>
 command creates a per-atom array with 6 columns:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">myPress</span> <span class="nb">all</span> <span class="n">stress</span><span class="o">/</span><span class="n">atom</span> <span class="n">NULL</span>
 <span class="n">dump</span> <span class="mi">2</span> <span class="nb">all</span> <span class="n">custom</span> <span class="mi">100</span> <span class="n">tmp</span><span class="o">.</span><span class="n">dump</span> <span class="nb">id</span> <span class="n">myPress</span><span class="p">[</span><span class="o">*</span><span class="p">]</span>

--- a/doc/html/dump_custom_vtk.html
+++ b/doc/html/dump_custom_vtk.html
@@ -157,7 +157,7 @@ mol = molecule ID
 proc = ID of processor that owns atom
 procp1 = ID+1 of processor that owns atom
 type = atom type
-element = name of atom element, as defined by <span class="xref doc">dump_modify</span> command
+element = name of atom element, as defined by <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify</span></a> command
 mass = atom mass
 x,y,z = unscaled atom coordinates
 xs,ys,zs = scaled atom coordinates
@@ -194,7 +194,7 @@ depending on the filename extension specified. This can be either
 for the XML format; see the <a class="reference external" href="http://www.vtk.org/VTK/img/file-formats.pdf">VTK homepage</a> for a detailed
 description of these formats.  Since this naming convention conflicts
 with the way binary output is usually specified (see below),
-<span class="xref doc">dump_modify binary</span> allows to set the binary
+<a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify binary</span></a> allows to set the binary
 flag for this dump style explicitly.</p>
 </div>
 <div class="section" id="description">
@@ -203,9 +203,9 @@ flag for this dump style explicitly.</p>
 timesteps in a format readable by the <a class="reference external" href="http://www.vtk.org">VTK visualization toolkit</a> or other visualization tools that use it,
 e.g. <a class="reference external" href="http://www.paraview.org">ParaView</a>.  The timesteps on which dump
 output is written can also be controlled by a variable; see the
-<span class="xref doc">dump_modify every</span> command for details.</p>
+<a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify every</span></a> command for details.</p>
 <p>Only information for atoms in the specified group is dumped.  The
-<span class="xref doc">dump_modify thresh and region</span> commands can also
+<a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify thresh and region</span></a> commands can also
 alter what atoms are included; see details below.</p>
 <p>As described below, special characters (&#8220;*&#8221;, &#8220;%&#8221;) in the filename
 determine the kind of output.</p>
@@ -218,7 +218,7 @@ box.</p>
 </div>
 <div class="admonition warning">
 <p class="first admonition-title">Warning</p>
-<p class="last">Unless the <span class="xref doc">dump_modify sort</span>
+<p class="last">Unless the <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify sort</span></a>
 option is invoked, the lines of atom information written to dump files
 will be in an indeterminate order for each snapshot.  This is even
 true when running on a single processor, if the <a class="reference internal" href="atom_modify.html"><span class="doc">atom_modify sort</span></a> option is on, which it is by default.  In this
@@ -228,7 +228,7 @@ data for a single snapshot is collected from multiple processors, each
 of which owns a subset of the atoms.</p>
 </div>
 <p>For the <em>custom/vtk</em> style, sorting is off by default. See the
-<span class="xref doc">dump_modify</span> doc page for details.</p>
+<a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify</span></a> doc page for details.</p>
 <hr class="docutils" />
 <p>The dimensions of the simulation box are written to a separate file
 for each snapshot (either in legacy VTK or XML format depending on
@@ -261,20 +261,20 @@ timestep 0) and on the last timestep of a minimization if the
 minimization converges.  Note that this means a dump will not be
 performed on the initial timestep after the dump command is invoked,
 if the current timestep is not a multiple of N.  This behavior can be
-changed via the <span class="xref doc">dump_modify first</span> command, which
+changed via the <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify first</span></a> command, which
 can also be useful if the dump command is invoked after a minimization
 ended on an arbitrary timestep.  N can be changed between runs by
-using the <span class="xref doc">dump_modify every</span> command.
-The <span class="xref doc">dump_modify every</span> command
+using the <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify every</span></a> command.
+The <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify every</span></a> command
 also allows a variable to be used to determine the sequence of
 timesteps on which dump files are written.  In this mode a dump on the
 first timestep of a run will also not be written unless the
-<span class="xref doc">dump_modify first</span> command is used.</p>
+<a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify first</span></a> command is used.</p>
 <p>Dump filenames can contain two wildcard characters.  If a &#8220;*&#8221;
 character appears in the filename, then one file per snapshot is
 written and the &#8220;*&#8221; character is replaced with the timestep value.
 For example, tmp.dump*.vtk becomes tmp.dump0.vtk, tmp.dump10000.vtk,
-tmp.dump20000.vtk, etc.  Note that the <span class="xref doc">dump_modify pad</span>
+tmp.dump20000.vtk, etc.  Note that the <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify pad</span></a>
 command can be used to insure all timestep numbers are the same length
 (e.g. 00010), which can make it easier to read a series of dump files
 in order with some post-processing tools.</p>
@@ -286,7 +286,7 @@ tmp.dump_P-1.vtp, etc.  This creates smaller files and can be a fast
 mode of output on parallel machines that support parallel I/O for output.</p>
 <p>By default, P = the number of processors meaning one file per
 processor, but P can be set to a smaller value via the <em>nfile</em> or
-<em>fileper</em> keywords of the <span class="xref doc">dump_modify</span> command.
+<em>fileper</em> keywords of the <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify</span></a> command.
 These options can be the most efficient way of writing out dump files
 when running on large numbers of processors.</p>
 <p>For the legacy VTK format &#8220;%&#8221; is ignored and P = 1, i.e., only
@@ -305,7 +305,7 @@ part of the <em>custom/vtk</em> style.</p>
 <p><em>id</em> is the atom ID.  <em>mol</em> is the molecule ID, included in the data
 file for molecular systems.  <em>type</em> is the atom type.  <em>element</em> is
 typically the chemical name of an element, which you must assign to
-each type via the <span class="xref doc">dump_modify element</span> command.
+each type via the <a class="reference internal" href="dump_modify.html"><span class="doc">dump_modify element</span></a> command.
 More generally, it can be any string you wish to associate with an
 atom type.  <em>mass</em> is the atom mass.  <em>vx</em>, <em>vy</em>, <em>vz</em>, <em>fx</em>, <em>fy</em>,
 <em>fz</em>, and <em>q</em> are components of atom velocity and force and atomic

--- a/doc/html/fix_ave_chunk.html
+++ b/doc/html/fix_ave_chunk.html
@@ -251,7 +251,7 @@ asterisk means all indices from n to N (inclusive).  A middle asterisk
 means all indices from m to n (inclusive).</p>
 <p>Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 fix ave/chunk commands are
-equivalent, since the <span class="xref doc">compute property/atom</span> command creates, in this
+equivalent, since the <a class="reference internal" href="compute_property_atom.html"><span class="doc">compute property/atom</span></a> command creates, in this
 case, a per-atom array with 3 columns:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="n">compute</span> <span class="n">myAng</span> <span class="nb">all</span> <span class="nb">property</span><span class="o">/</span><span class="n">atom</span> <span class="n">angmomx</span> <span class="n">angmomy</span> <span class="n">angmomz</span>
 <span class="n">fix</span> <span class="mi">1</span> <span class="nb">all</span> <span class="n">ave</span><span class="o">/</span><span class="n">chunk</span> <span class="mi">100</span> <span class="mi">1</span> <span class="mi">100</span> <span class="n">cc1</span> <span class="n">c_myAng</span><span class="p">[</span><span class="o">*</span><span class="p">]</span> <span class="n">file</span> <span class="n">tmp</span><span class="o">.</span><span class="n">angmom</span>
@@ -262,7 +262,7 @@ case, a per-atom array with 3 columns:</p>
 <p class="first admonition-title">Note</p>
 <p class="last">This fix works by creating an array of size <em>Nchunk</em> by Nvalues
 on each processor.  <em>Nchunk</em> is the number of chunks which is defined
-by the <span class="xref doc">compute chunk/atom</span> command.
+by the <a class="reference internal" href="compute_chunk_atom.html"><span class="doc">compute chunk/atom</span></a> command.
 Nvalues is the number of input values specified.  Each processor loops
 over its atoms, tallying its values to the appropriate chunk.  Then
 the entire array is summed across all processors.  This means that

--- a/doc/html/fix_bond_create.html
+++ b/doc/html/fix_bond_create.html
@@ -237,7 +237,7 @@ become one moleclue due to the created bond, all atoms in the new
 moleclue retain their original molecule IDs.</p>
 </div>
 <p>If the <em>atype</em> keyword is used and if an angle potential is defined
-via the <span class="xref doc">angle_style</span> command, then any new 3-body
+via the <a class="reference internal" href="angle_style.html"><span class="doc">angle_style</span></a> command, then any new 3-body
 interactions inferred by the creation of a bond will create new angles
 of type <em>angletype</em>, with parameters assigned by the corresponding
 <a class="reference internal" href="angle_coeff.html"><span class="doc">angle_coeff</span></a> command.  Likewise, the <em>dtype</em> and

--- a/doc/html/fix_deform.html
+++ b/doc/html/fix_deform.html
@@ -570,7 +570,7 @@ is not consistent with fix nvt/sllod.</p>
 <p class="last">For non-equilibrium MD (NEMD) simulations using &#8220;remap v&#8221; it is
 usually desirable that the fluid (or flowing material, e.g. granular
 particles) stream with a velocity profile consistent with the
-deforming box.  As mentioned above, using a thermostat such as <a class="reference internal" href="fix_nvt_sllod.html"><span class="doc">fix nvt/sllod</span></a> or <span class="xref doc">fix lavgevin</span>
+deforming box.  As mentioned above, using a thermostat such as <a class="reference internal" href="fix_nvt_sllod.html"><span class="doc">fix nvt/sllod</span></a> or <a class="reference internal" href="fix_langevin.html"><span class="doc">fix lavgevin</span></a>
 (with a bias provided by <a class="reference internal" href="compute_temp_deform.html"><span class="doc">compute temp/deform</span></a>), will typically accomplish
 that.  If you do not use a thermostat, then there is no driving force
 pushing the atoms to flow in a manner consistent with the deforming

--- a/doc/html/fix_deposit.html
+++ b/doc/html/fix_deposit.html
@@ -264,7 +264,7 @@ time a molecule is deposited, a random number is used to sample from
 the list of relative probabilities.  The N values must sum to 1.0.</p>
 <p>If you wish to insert molecules via the <em>mol</em> keyword, that will be
 treated as rigid bodies, use the <em>rigid</em> keyword, specifying as its
-value the ID of a separate <span class="xref doc">fix rigid/small</span>
+value the ID of a separate <a class="reference internal" href="fix_rigid.html"><span class="doc">fix rigid/small</span></a>
 command which also appears in your input script.</p>
 <p>If you wish to insert molecules via the <em>mol</em> keyword, that will have
 their bonds or angles constrained via SHAKE, use the <em>shake</em> keyword,

--- a/doc/html/fix_ehex.html
+++ b/doc/html/fix_ehex.html
@@ -231,7 +231,7 @@ resulting temperature profile will therefore be the same.</p>
 the keyword <em>hex</em> is specified.</p>
 <hr class="docutils" />
 <p><strong>Compatibility with SHAKE and RATTLE (rigid molecules)</strong>:</p>
-<p>This fix is compatible with <a class="reference internal" href="fix_shake.html"><span class="doc">fix shake</span></a> and <span class="xref doc">fix rattle</span>. If either of these constraining algorithms is
+<p>This fix is compatible with <a class="reference internal" href="fix_shake.html"><span class="doc">fix shake</span></a> and <a class="reference internal" href="fix_shake.html"><span class="doc">fix rattle</span></a>. If either of these constraining algorithms is
 specified in the input script and the keyword <em>constrain</em> is set, the
 bond distances will be corrected a second time at the end of the
 integration step.  It is recommended to specify the keyword <em>com</em> in
@@ -244,7 +244,7 @@ rescaling takes place if the centre of mass lies outside the region.</p>
 <p class="first admonition-title">Note</p>
 <p class="last">You can only use the keyword <em>com</em> along with <em>constrain</em>.</p>
 </div>
-<p>To achieve the highest accuracy it is recommended to use <span class="xref doc">fix rattle</span> with the keywords <em>constrain</em> and <em>com</em> as
+<p>To achieve the highest accuracy it is recommended to use <a class="reference internal" href="fix_shake.html"><span class="doc">fix rattle</span></a> with the keywords <em>constrain</em> and <em>com</em> as
 shown in the second example. Only if RATTLE is employed, the velocity
 constraints will be satisfied.</p>
 <div class="admonition note">

--- a/doc/html/fix_eos_table.html
+++ b/doc/html/fix_eos_table.html
@@ -187,7 +187,7 @@ identifies the section.  The line can contain additional text, but the
 initial text must match the argument specified in the fix command.</p>
 <p>The next line lists the number of table entries.  The parameter &#8220;N&#8221; is
 required and its value is the number of table entries that follow.
-Note that this may be different than the <em>N</em> specified in the <span class="xref doc">fix eos/table</span> command.  Let Ntable = <em>N</em> in the fix
+Note that this may be different than the <em>N</em> specified in the <a class="reference internal" href="#"><span class="doc">fix eos/table</span></a> command.  Let Ntable = <em>N</em> in the fix
 command, and Nfile = &#8220;N&#8221; in the tabulated file.  What LAMMPS does is a
 preliminary interpolation by creating splines using the Nfile
 tabulated values as nodal points.  It uses these to interpolate as
@@ -220,7 +220,7 @@ are not within the table cutoffs.</p>
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><a class="reference internal" href="fix_shardlow.html"><span class="doc">fix shardlow</span></a>, <span class="xref doc">pair dpd/fdt</span></p>
+<p><a class="reference internal" href="fix_shardlow.html"><span class="doc">fix shardlow</span></a>, <a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair dpd/fdt</span></a></p>
 <p><strong>Default:</strong> none</p>
 </div>
 </div>

--- a/doc/html/fix_eos_table_rx.html
+++ b/doc/html/fix_eos_table_rx.html
@@ -242,7 +242,7 @@ are not within the table cutoffs.</p>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
 <p><a class="reference internal" href="fix_rx.html"><span class="doc">fix rx</span></a>,
-<span class="xref doc">pair dpd/fdt</span></p>
+<a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair dpd/fdt</span></a></p>
 <p><strong>Default:</strong> none</p>
 <hr class="docutils" />
 </div>

--- a/doc/html/fix_lb_momentum.html
+++ b/doc/html/fix_lb_momentum.html
@@ -172,7 +172,7 @@ dimension.</p>
 <h2>Restart, fix_modify, output, run start/stop, minimize info</h2>
 <p>No information about this fix is written to <a class="reference internal" href="restart.html"><span class="doc">binary restart files</span></a>.  None of the <a class="reference internal" href="fix_modify.html"><span class="doc">fix_modify</span></a> options
 are relevant to this fix.  No global or per-atom quantities are stored
-by this fix for access by various <span class="xref std std-ref">output commands</span>.  No parameter of this fix can be
+by this fix for access by various <a class="reference internal" href="Section_howto.html#howto-15"><span class="std std-ref">output commands</span></a>.  No parameter of this fix can be
 used with the <em>start/stop</em> keywords of the <a class="reference internal" href="run.html"><span class="doc">run</span></a> command.
 This fix is not invoked during <a class="reference internal" href="minimize.html"><span class="doc">energy minimization</span></a>.</p>
 </div>

--- a/doc/html/fix_lb_pc.html
+++ b/doc/html/fix_lb_pc.html
@@ -154,7 +154,7 @@ algorithm if the force coupling constant has been set by default.</p>
 <h2>Restart, fix_modify, output, run start/stop, minimize info</h2>
 <p>No information about this fix is written to <a class="reference internal" href="restart.html"><span class="doc">binary restart files</span></a>.  None of the <a class="reference internal" href="fix_modify.html"><span class="doc">fix_modify</span></a> options
 are relevant to this fix.  No global or per-atom quantities are stored
-by this fix for access by various <span class="xref std std-ref">output commands</span>.  No parameter of this fix can be
+by this fix for access by various <a class="reference internal" href="Section_howto.html#howto-15"><span class="std std-ref">output commands</span></a>.  No parameter of this fix can be
 used with the <em>start/stop</em> keywords of the <a class="reference internal" href="run.html"><span class="doc">run</span></a> command.
 This fix is not invoked during <a class="reference internal" href="minimize.html"><span class="doc">energy minimization</span></a>.</p>
 </div>

--- a/doc/html/fix_nh_eff.html
+++ b/doc/html/fix_nh_eff.html
@@ -203,7 +203,7 @@ to the temperature or kinetic energy from the electron radial velocity.</p>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">there are two different pressures that can be reported for eFF
-when defining the pair_style (see <span class="xref doc">pair eff/cut</span> to
+when defining the pair_style (see <a class="reference internal" href="pair_eff.html"><span class="doc">pair eff/cut</span></a> to
 understand these settings), one (default) that considers electrons do
 not contribute radial virial components (i.e. electrons treated as
 incompressible &#8216;rigid&#8217; spheres) and one that does.  The radial

--- a/doc/html/fix_nve_manifold_rattle.html
+++ b/doc/html/fix_nve_manifold_rattle.html
@@ -159,7 +159,7 @@ keyword = <em>every</em>
 atoms constrained to a curved surface (manifold) in the group each
 timestep. The constraint is handled by RATTLE <a class="reference internal" href="fix_shake.html#andersen"><span class="std std-ref">(Andersen)</span></a>
 written out for the special case of single-particle constraints as
-explained in <a class="reference internal" href="fix_nvt_manifold_rattle.html#paquay"><span class="std std-ref">(Paquay)</span></a>.  V is volume; E is energy. This way,
+explained in <a class="reference internal" href="manifolds.html#paquay"><span class="std std-ref">(Paquay)</span></a>.  V is volume; E is energy. This way,
 the dynamics of particles constrained to curved surfaces can be
 studied. If combined with <a class="reference internal" href="fix_langevin.html"><span class="doc">fix langevin</span></a>, this
 generates Brownian motion of particles constrained to a curved

--- a/doc/html/fix_nvt_manifold_rattle.html
+++ b/doc/html/fix_nvt_manifold_rattle.html
@@ -157,7 +157,7 @@ keyword = <em>temp</em> or <em>tchain</em> or <em>every</em>
 </div>
 <div class="section" id="description">
 <h2>Description</h2>
-<p>This fix combines the RATTLE-based <a class="reference internal" href="fix_shake.html#andersen"><span class="std std-ref">(Andersen)</span></a> time integrator of <a class="reference internal" href="fix_nve_manifold_rattle.html"><span class="doc">fix nve/manifold/rattle</span></a> <a class="reference internal" href="#paquay"><span class="std std-ref">(Paquay)</span></a> with a Nose-Hoover-chain thermostat to sample the
+<p>This fix combines the RATTLE-based <a class="reference internal" href="fix_shake.html#andersen"><span class="std std-ref">(Andersen)</span></a> time integrator of <a class="reference internal" href="fix_nve_manifold_rattle.html"><span class="doc">fix nve/manifold/rattle</span></a> <a class="reference internal" href="manifolds.html#paquay"><span class="std std-ref">(Paquay)</span></a> with a Nose-Hoover-chain thermostat to sample the
 canonical ensemble of particles constrained to a curved surface (manifold). This sampling does suffer from discretization bias of O(dt).
 For a list of currently supported manifolds and their parameters, see <a class="reference internal" href="manifolds.html"><span class="doc">manifolds</span></a></p>
 </div>

--- a/doc/html/fix_phonon.html
+++ b/doc/html/fix_phonon.html
@@ -247,7 +247,7 @@ corresponding reciprocal lattice.</p>
 fix. You can use it to change the temperature compute from thermo_temp
 to the one that reflects the true temperature of atoms in the group.</p>
 <p>No global scalar or vector or per-atom quantities are stored by this
-fix for access by various <span class="xref std std-ref">output commands</span>.</p>
+fix for access by various <a class="reference internal" href="Section_howto.html#howto-15"><span class="std std-ref">output commands</span></a>.</p>
 <p>Instead, this fix outputs its initialization information (including
 mapping information) and the calculated dynamical matrices to the file
 <em>prefix</em>.log, with the specified <em>prefix</em>.  The dynamical matrices are

--- a/doc/html/fix_pour.html
+++ b/doc/html/fix_pour.html
@@ -232,7 +232,7 @@ time a molecule is inserted, a random number is used to sample from
 the list of relative probabilities.  The N values must sum to 1.0.</p>
 <p>If you wish to insert molecules via the <em>mol</em> keyword, that will be
 treated as rigid bodies, use the <em>rigid</em> keyword, specifying as its
-value the ID of a separate <span class="xref doc">fix rigid/small</span>
+value the ID of a separate <a class="reference internal" href="fix_rigid.html"><span class="doc">fix rigid/small</span></a>
 command which also appears in your input script.</p>
 <p>If you wish to insert molecules via the <em>mol</em> keyword, that will have
 their bonds or angles constrained via SHAKE, use the <em>shake</em> keyword,

--- a/doc/html/fix_reax_bonds.html
+++ b/doc/html/fix_reax_bonds.html
@@ -155,7 +155,7 @@ specified by <a class="reference internal" href="pair_reax.html"><span class="do
 stand-alone ReaxFF code of Adri van Duin.  The bond information is
 written to <em>filename</em> on timesteps that are multiples of <em>Nevery</em>,
 including timestep 0.  For time-averaged chemical species analysis,
-please see the <span class="xref doc">fix species</span> command.</p>
+please see the <a class="reference internal" href="fix_reaxc_species.html"><span class="doc">fix reaxc/c/species</span></a> command.</p>
 <p>The format of the output file should be self-explantory.</p>
 </div>
 <hr class="docutils" />

--- a/doc/html/fix_rx.html
+++ b/doc/html/fix_rx.html
@@ -292,7 +292,7 @@ enthalpy DPD simulation.</p>
 <h2>Related commands</h2>
 <p><a class="reference internal" href="fix_eos_table_rx.html"><span class="doc">fix eos/table/rx</span></a>,
 <a class="reference internal" href="fix_shardlow.html"><span class="doc">fix shardlow</span></a>,
-<span class="xref doc">pair dpd/fdt/energy</span></p>
+<a class="reference internal" href="pair_dpd_fdt.html"><span class="doc">pair dpd/fdt/energy</span></a></p>
 <p><strong>Default:</strong> none</p>
 </div>
 </div>

--- a/doc/html/fix_shardlow.html
+++ b/doc/html/fix_shardlow.html
@@ -148,7 +148,7 @@
 integrate the DPD equations of motion.  The SSA splits the integration
 into a stochastic and deterministic integration step.  The fix
 <em>shardlow</em> performs the stochastic integration step and must be used
-in conjunction with a deterministic integrator (e.g. <a class="reference internal" href="fix_nve.html"><span class="doc">fix nve</span></a> or <span class="xref doc">fix nph</span>).  The stochastic
+in conjunction with a deterministic integrator (e.g. <a class="reference internal" href="fix_nve.html"><span class="doc">fix nve</span></a> or <a class="reference internal" href="fix_nh.html"><span class="doc">fix nph</span></a>).  The stochastic
 integration of the dissipative and random forces is performed prior to
 the deterministic integration of the conservative force. Further
 details regarding the method are provided in <a class="reference internal" href="pair_dpd_fdt.html#lisal"><span class="std std-ref">(Lisal)</span></a> and

--- a/doc/html/fix_smd.html
+++ b/doc/html/fix_smd.html
@@ -168,10 +168,10 @@
 <div class="section" id="description">
 <h2>Description</h2>
 <p>This fix implements several options of steered MD (SMD) as reviewed in
-<span class="xref std std-ref">(Izrailev)</span>, which allows to induce conformational changes
+<a class="reference internal" href="#izrailev"><span class="std std-ref">(Izrailev)</span></a>, which allows to induce conformational changes
 in systems and to compute the potential of mean force (PMF) along the
-assumed reaction coordinate <span class="xref std std-ref">(Park)</span> based on Jarzynski&#8217;s
-equality <span class="xref std std-ref">(Jarzynski)</span>.  This fix borrows a lot from <a class="reference internal" href="fix_spring.html"><span class="doc">fix spring</span></a> and <a class="reference internal" href="fix_setforce.html"><span class="doc">fix setforce</span></a>.</p>
+assumed reaction coordinate <a class="reference internal" href="#park"><span class="std std-ref">(Park)</span></a> based on Jarzynski&#8217;s
+equality <a class="reference internal" href="#jarzynski"><span class="std std-ref">(Jarzynski)</span></a>.  This fix borrows a lot from <a class="reference internal" href="fix_spring.html"><span class="doc">fix spring</span></a> and <a class="reference internal" href="fix_setforce.html"><span class="doc">fix setforce</span></a>.</p>
 <p>You can apply a moving spring force to a group of atoms (<em>tether</em>
 style) or between two groups of atoms (<em>couple</em> style).  The spring
 can then be used in either constant velocity (<em>cvel</em>) mode or in
@@ -249,14 +249,12 @@ LAMMPS was built with that package.  See the <a class="reference internal" href=
 <a class="reference internal" href="fix_spring_rg.html"><span class="doc">fix spring/rg</span></a></p>
 <p><strong>Default:</strong> none</p>
 <hr class="docutils" />
-<p id="israilev"><strong>(Izrailev)</strong> Izrailev, Stepaniants, Isralewitz, Kosztin, Lu, Molnar,
+<p id="izrailev"><strong>(Izrailev)</strong> Izrailev, Stepaniants, Isralewitz, Kosztin, Lu, Molnar,
 Wriggers, Schulten. Computational Molecular Dynamics: Challenges,
 Methods, Ideas, volume 4 of Lecture Notes in Computational Science and
 Engineering, pp. 39-65. Springer-Verlag, Berlin, 1998.</p>
-<p><strong>(Park)</strong>
-Park, Schulten, J. Chem. Phys. 120 (13), 5946 (2004)</p>
-<p><strong>(Jarzynski)</strong>
-Jarzynski, Phys. Rev. Lett. 78, 2690 (1997)</p>
+<p id="park"><strong>(Park)</strong> Park, Schulten, J. Chem. Phys. 120 (13), 5946 (2004)</p>
+<p id="jarzynski"><strong>(Jarzynski)</strong> Jarzynski, Phys. Rev. Lett. 78, 2690 (1997)</p>
 </div>
 </div>
 

--- a/doc/html/fix_wall_piston.html
+++ b/doc/html/fix_wall_piston.html
@@ -205,7 +205,7 @@ define the lattice spacings.</p>
 <h2>Restart, fix_modify, output, run start/stop, minimize info</h2>
 <p>No information about this fix is written to <a class="reference internal" href="restart.html"><span class="doc">binary restart files</span></a>.  None of the <a class="reference internal" href="fix_modify.html"><span class="doc">fix_modify</span></a> options
 are relevant to this fix.  No global or per-atom quantities are stored
-by this fix for access by various <span class="xref std std-ref">output commands</span>.  No parameter of this fix can
+by this fix for access by various <a class="reference internal" href="Section_howto.html#howto-15"><span class="std std-ref">output commands</span></a>.  No parameter of this fix can
 be used with the <em>start/stop</em> keywords of the <a class="reference internal" href="run.html"><span class="doc">run</span></a> command.
 This fix is not invoked during <a class="reference internal" href="minimize.html"><span class="doc">energy minimization</span></a>.</p>
 </div>

--- a/doc/html/genindex.html
+++ b/doc/html/genindex.html
@@ -1226,7 +1226,7 @@
   </dt>
 
       
-  <dt><a href="fix_nve.html#index-0">fix nve</a>, <a href="foo.html#index-0">[1]</a>
+  <dt><a href="fix_nve.html#index-0">fix nve</a>
   </dt>
 
       

--- a/doc/html/kspace_style.html
+++ b/doc/html/kspace_style.html
@@ -195,7 +195,7 @@ style, the cutoff for Coulombic or 1/r^N interactions is effectively
 infinite.  If the Coulombic case, this means each charge in the system
 interacts with charges in an infinite array of periodic images of the
 simulation domain.</p>
-<p>Note that using a long-range solver requires use of a matching <span class="xref doc">pair style</span> to perform consistent short-range pairwise
+<p>Note that using a long-range solver requires use of a matching <a class="reference internal" href="pair_style.html"><span class="doc">pair style</span></a> to perform consistent short-range pairwise
 calculations.  This means that the name of the pair style contains a
 matching keyword to the name of the KSpace style, as in this table:</p>
 <table border="1" class="docutils">

--- a/doc/html/molecule.html
+++ b/doc/html/molecule.html
@@ -297,7 +297,7 @@ manner.</p>
 <p class="last">Whether a section is required depends on how the molecule
 template is used by other LAMMPS commands.  For example, to add a
 molecule via the <a class="reference internal" href="fix_deposit.html"><span class="doc">fix deposit</span></a> command, the Coords
-and Types sections are required.  To add a rigid body via the <span class="xref doc">fix pour</span> command, the Bonds (Angles, etc) sections are not
+and Types sections are required.  To add a rigid body via the <a class="reference internal" href="fix_pour.html"><span class="doc">fix pour</span></a> command, the Bonds (Angles, etc) sections are not
 required, since the molecule will be treated as a rigid body.  Some
 sections are optional.  For example, the <a class="reference internal" href="fix_pour.html"><span class="doc">fix pour</span></a>
 command can be used to add &#8220;molecules&#8221; which are clusters of

--- a/doc/html/neighbor.html
+++ b/doc/html/neighbor.html
@@ -192,7 +192,7 @@ are printed to the screen and log file.  See <a class="reference internal" href=
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
 <p><a class="reference internal" href="neigh_modify.html"><span class="doc">neigh_modify</span></a>, <a class="reference internal" href="units.html"><span class="doc">units</span></a>,
-<span class="xref doc">comm_modify</span></p>
+<a class="reference internal" href="comm_modify.html"><span class="doc">comm_modify</span></a></p>
 </div>
 <div class="section" id="default">
 <h2>Default</h2>

--- a/doc/html/pair_brownian.html
+++ b/doc/html/pair_brownian.html
@@ -227,7 +227,7 @@ to be specified in an input script that reads a restart file.</p>
 <div class="section" id="restrictions">
 <h2>Restrictions</h2>
 <p>These styles are part of the COLLOID package.  They are only enabled
-if LAMMPS was built with that package.  See the <span class="xref std std-ref">Making LAMMPS</span> section for more info.</p>
+if LAMMPS was built with that package.  See the <a class="reference internal" href="Section_start.html#start-3"><span class="std std-ref">Making LAMMPS</span></a> section for more info.</p>
 <p>Only spherical monodisperse particles are allowed for pair_style
 brownian.</p>
 <p>Only spherical particles are allowed for pair_style brownian/poly.</p>

--- a/doc/html/pair_dipole.html
+++ b/doc/html/pair_dipole.html
@@ -268,17 +268,15 @@ dipole interactions.  The long-range portion is calculated by using
 <em>ewald_disp</em> of the <a class="reference internal" href="kspace_style.html"><span class="doc">kspace_style</span></a> command. If
 <em>flag_coul</em> is set to <em>off</em>, Coulombic and dipole interactions are not
 computed at all.</p>
-<p>Atoms with dipole moments should be integrated using the <a class="reference internal" href="fix_nve_sphere.html"><span class="doc">fix nve/sphere update dipole</span></a> command to rotate the
+<p>Atoms with dipole moments should be integrated using the <a class="reference internal" href="fix_nve_sphere.html"><span class="doc">fix nve/sphere update dipole</span></a> or the <a class="reference internal" href="fix_nvt_sphere.html"><span class="doc">fix nvt/sphere update dipole</span></a> command to rotate the
 dipole moments.  The <em>omega</em> option on the <a class="reference internal" href="fix_langevin.html"><span class="doc">fix langevin</span></a> command can be used to thermostat the
 rotational motion.  The <a class="reference internal" href="compute_temp_sphere.html"><span class="doc">compute temp/sphere</span></a>
 command can be used to monitor the temperature, since it includes
-rotational degrees of freedom.  The <a class="reference internal" href="atom_style.html"><span class="doc">atom_style dipole</span></a> command should be used since it defines the
-point dipoles and their rotational state.  The magnitude of the dipole
-moment for each type of particle can be defined by the
-<span class="xref doc">dipole</span> command or in the &#8220;Dipoles&#8221; section of the data
-file read in by the <a class="reference internal" href="read_data.html"><span class="doc">read_data</span></a> command.  Their initial
-orientation can be defined by the <a class="reference internal" href="set.html"><span class="doc">set dipole</span></a> command or in
-the &#8220;Atoms&#8221; section of the data file.</p>
+rotational degrees of freedom.  The <a class="reference internal" href="atom_style.html"><span class="doc">atom_style hybrid dipole sphere</span></a> command should be used since
+it defines the point dipoles and their rotational state.
+The magnitude and orientation of the dipole moment for each particle
+can be defined by the <a class="reference internal" href="set.html"><span class="doc">set</span></a> command or in the &#8220;Atoms&#8221; section
+of the data file read in by the <a class="reference internal" href="read_data.html"><span class="doc">read_data</span></a> command.</p>
 <p>The following coefficients must be defined for each pair of atoms
 types via the <a class="reference internal" href="pair_coeff.html"><span class="doc">pair_coeff</span></a> command as in the examples
 above, or in the data file or restart files read by the
@@ -348,7 +346,8 @@ currently supported.</p>
 </div>
 <div class="section" id="related-commands">
 <h2>Related commands</h2>
-<p><a class="reference internal" href="pair_coeff.html"><span class="doc">pair_coeff</span></a></p>
+<p><a class="reference internal" href="pair_coeff.html"><span class="doc">pair_coeff</span></a>, <a class="reference internal" href="set.html"><span class="doc">set</span></a>, <a class="reference internal" href="read_data.html"><span class="doc">read_data</span></a>,
+<a class="reference internal" href="fix_nve_sphere.html"><span class="doc">fix nve/sphere</span></a>, <a class="reference internal" href="fix_nvt_sphere.html"><span class="doc">fix nvt/sphere</span></a></p>
 <p><strong>Default:</strong> none</p>
 <hr class="docutils" />
 <p id="allen"><strong>(Allen)</strong> Allen and Tildesley, Computer Simulation of Liquids,

--- a/doc/html/pair_dpd_fdt.html
+++ b/doc/html/pair_dpd_fdt.html
@@ -230,7 +230,7 @@ specified.</p>
 <p>These commands are part of the USER-DPD package.  They are only
 enabled if LAMMPS was built with that package.  See the <a class="reference internal" href="Section_start.html#start-3"><span class="std std-ref">Making LAMMPS</span></a> section for more info.</p>
 <p>Pair styles <em>dpd/fdt</em> and <em>dpd/fdt/energy</em> require use of the
-<span class="xref doc">communicate vel yes</span> option so that velocites are
+<a class="reference internal" href="comm_modify.html"><span class="doc">comm_modify vel yes</span></a> option so that velocites are
 stored by ghost atoms.</p>
 <p>Pair style <em>dpd/fdt/energy</em> requires <a class="reference internal" href="atom_style.html"><span class="doc">atom_style dpd</span></a>
 to be used in order to properly account for the particle internal

--- a/doc/html/pair_gayberne.html
+++ b/doc/html/pair_gayberne.html
@@ -288,7 +288,7 @@ enabled if LAMMPS was built with that package.  See the <a class="reference inte
 <p>These pair style require that atoms store torque and a quaternion to
 represent their orientation, as defined by the
 <a class="reference internal" href="atom_style.html"><span class="doc">atom_style</span></a>.  It also require they store a per-type
-<span class="xref doc">shape</span>.  The particles cannot store a per-particle
+<a class="reference internal" href="set.html"><span class="doc">shape</span></a>.  The particles cannot store a per-particle
 diameter.</p>
 <p>This pair style requires that atoms be ellipsoids as defined by the
 <a class="reference internal" href="atom_style.html"><span class="doc">atom_style ellipsoid</span></a> command.</p>

--- a/doc/html/pair_line_lj.html
+++ b/doc/html/pair_line_lj.html
@@ -238,7 +238,7 @@ shift, table, and tail options.</p>
 <div class="section" id="restrictions">
 <h2>Restrictions</h2>
 <p>This style is part of the ASPHERE package.  It is only enabled if
-LAMMPS was built with that package.  See the <span class="xref std std-ref">Making LAMMPS</span> section for more info.</p>
+LAMMPS was built with that package.  See the <a class="reference internal" href="Section_start.html#start-3"><span class="std std-ref">Making LAMMPS</span></a> section for more info.</p>
 <p>Defining particles to be line segments so they participate in
 line/line or line/particle interactions requires the use the
 <a class="reference internal" href="atom_style.html"><span class="doc">atom_style line</span></a> command.</p>

--- a/doc/html/pair_thole.html
+++ b/doc/html/pair_thole.html
@@ -180,7 +180,7 @@ it also allows for mixing pair coefficients instead of listing them all.
 The <em>lj/cut/thole/long</em> pair style is also a bit faster because it avoids an
 overlay and can benefit from OMP acceleration. Moreover, it uses a more
 precise approximation of the direct Coulomb interaction at short range similar
-to <span class="xref doc">coul/long/cs</span>, which stabilizes the temperature of
+to <a class="reference internal" href="pair_cs.html"><span class="doc">coul/long/cs</span></a>, which stabilizes the temperature of
 Drude particles.</p>
 <p>The <em>thole</em> pair styles compute the Coulomb interaction damped at
 short distances by a function</p>

--- a/doc/html/pair_tri_lj.html
+++ b/doc/html/pair_tri_lj.html
@@ -210,7 +210,7 @@ shift, table, and tail options.</p>
 <div class="section" id="restrictions">
 <h2>Restrictions</h2>
 <p>This style is part of the ASPHERE package.  It is only enabled if
-LAMMPS was built with that package.  See the <span class="xref std std-ref">Making LAMMPS</span> section for more info.</p>
+LAMMPS was built with that package.  See the <a class="reference internal" href="Section_start.html#start-3"><span class="std std-ref">Making LAMMPS</span></a> section for more info.</p>
 <p>Defining particles to be triangles so they participate in tri/tri or
 tri/particle interactions requires the use the <a class="reference internal" href="atom_style.html"><span class="doc">atom_style tri</span></a> command.</p>
 </div>

--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -554,7 +554,7 @@ building LAMMPS.  LAMMPS must also be built as a shared library and
 your Python function must be able to to load the Python module in
 python/lammps.py that wraps the LAMMPS library interface.  These are
 the same steps required to use Python by itself to wrap LAMMPS.
-Details on these steps are explained in <span class="xref doc">Section python</span>.  Note that it is important that the
+Details on these steps are explained in <a class="reference internal" href="Section_python.html"><span class="doc">Section python</span></a>.  Note that it is important that the
 stand-alone LAMMPS executable and the LAMMPS shared library be
 consistent (built from the same source code files) in order for this
 to work.  If the two have been built at different times using

--- a/doc/html/rerun.html
+++ b/doc/html/rerun.html
@@ -174,7 +174,7 @@ initial simulation produced the dump file:</p>
 <li>Calculate one or more diagnostic quantities on the snapshots that
 weren&#8217;t computed in the initial run.  These can also be computed with
 settings not used in the initial run, e.g. computing an RDF via the
-<span class="xref doc">compute rdf</span> command with a longer cutoff than was
+<a class="reference internal" href="compute_rdf.html"><span class="doc">compute rdf</span></a> command with a longer cutoff than was
 used initially.</li>
 <li>Calculate the portion of per-atom forces resulting from a subset of
 the potential.  E.g. compute only Coulombic forces.  This can be done

--- a/doc/html/search.html
+++ b/doc/html/search.html
@@ -120,18 +120,19 @@
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
             
-  <noscript>
-  <div id="fallback" class="admonition warning">
-    <p class="last">
-      Please activate JavaScript to enable the search
-      functionality.
-    </p>
-  </div>
-  </noscript>
-
-  
   <div id="search-results">
-  
+<script>
+  (function() {
+    var cx = '012685039201307511604:um7if1hinba';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:searchresults-only></gcse:searchresults-only>
   </div>
 
            </div>
@@ -177,7 +178,6 @@
       <script type="text/javascript" src="_static/sphinxcontrib-images/LightBox2/lightbox2/js/jquery-1.11.0.min.js"></script>
       <script type="text/javascript" src="_static/sphinxcontrib-images/LightBox2/lightbox2/js/lightbox.min.js"></script>
       <script type="text/javascript" src="_static/sphinxcontrib-images/LightBox2/lightbox2-customize/jquery-noconflict.js"></script>
-      <script type="text/javascript" src="_static/searchtools.js"></script>
 
   
 
@@ -194,12 +194,6 @@
       });
   </script>
   
-  <script type="text/javascript">
-    jQuery(function() { Search.loadIndex("searchindex.js"); });
-  </script>
-  
-  <script type="text/javascript" id="searchindexloader"></script>
-   
 
 
 </body>

--- a/doc/html/variable.html
+++ b/doc/html/variable.html
@@ -1192,7 +1192,7 @@ with a leading $ sign (e.g. $x or ${abc}) versus with a leading &#8220;<a href="
 (e.g. v_x or v_abc).  The former can be used in any input script
 command, including a variable command.  The input script parser
 evaluates the reference variable immediately and substitutes its value
-into the command.  As explained in <span class="xref std std-ref">Section commands 3.2</span> for &#8220;Parsing rules&#8221;, you can also use
+into the command.  As explained in <a class="reference internal" href="Section_commands.html#cmd-2"><span class="std std-ref">Section commands 3.2</span></a> for &#8220;Parsing rules&#8221;, you can also use
 un-named &#8220;immediate&#8221; variables for this purpose.  For example, a
 string like this $((xlo+xhi)/2+sqrt(v_area)) in an input script
 command evaluates the string between the parenthesis as an equal-style

--- a/doc/src/Section_howto.txt
+++ b/doc/src/Section_howto.txt
@@ -1010,7 +1010,7 @@ system.  Fix nvt/sllod uses "compute
 temp/deform"_compute_temp_deform.html to compute a thermal temperature
 by subtracting out the streaming velocity of the shearing atoms.  The
 velocity profile or other properties of the fluid can be monitored via
-the "fix ave/spatial"_fix_ave_spatial.html command.
+the "fix ave/chunk"_fix_ave_chunk.html command.
 
 As discussed in the previous section on non-orthogonal simulation
 boxes, the amount of tilt or skew that can be applied is limited by
@@ -1970,7 +1970,7 @@ on each of two regions to add/subtract specified amounts of energy to
 both regions.  In both cases, the resulting temperatures of the two
 regions can be monitored with the "compute temp/region" command and
 the temperature profile of the intermediate region can be monitored
-with the "fix ave/spatial"_fix_ave_spatial.html and "compute
+with the "fix ave/chunk"_fix_ave_chunk.html and "compute
 ke/atom"_compute_ke_atom.html commands.
 
 The third method is to perform a reverse non-equilibrium MD simulation
@@ -1979,7 +1979,7 @@ command which implements the rNEMD algorithm of Muller-Plathe.
 Kinetic energy is swapped between atoms in two different layers of the
 simulation box.  This induces a temperature gradient between the two
 layers which can be monitored with the "fix
-ave/spatial"_fix_ave_spatial.html and "compute
+ave/chunk"_fix_ave_chunk.html and "compute
 ke/atom"_compute_ke_atom.html commands.  The fix tallies the
 cumulative energy transfer that it performs.  See the "fix
 thermal/conductivity"_fix_thermal_conductivity.html command for
@@ -2036,7 +2036,7 @@ velocity to prevent the fluid from heating up.
 
 In both cases, the velocity profile setup in the fluid by this
 procedure can be monitored by the "fix
-ave/spatial"_fix_ave_spatial.html command, which determines
+ave/chunk"_fix_ave_chunk.html command, which determines
 grad(Vstream) in the equation above.  E.g. the derivative in the
 y-direction of the Vx component of fluid motion or grad(Vstream) =
 dVx/dy.  The Pxy off-diagonal component of the pressure or stress
@@ -2050,7 +2050,7 @@ using the "fix viscosity"_fix_viscosity.html command which implements
 the rNEMD algorithm of Muller-Plathe.  Momentum in one dimension is
 swapped between atoms in two different layers of the simulation box in
 a different dimension.  This induces a velocity gradient which can be
-monitored with the "fix ave/spatial"_fix_ave_spatial.html command.
+monitored with the "fix ave/chunk"_fix_ave_chunk.html command.
 The fix tallies the cummulative momentum transfer that it performs.
 See the "fix viscosity"_fix_viscosity.html command for details.
 

--- a/doc/src/Section_intro.txt
+++ b/doc/src/Section_intro.txt
@@ -260,7 +260,7 @@ calculate "virtual diffraction patterns"_compute_xrd.html
 coupled rigid body integration via the "POEMS"_fix_poems.html library
 "QM/MM coupling"_fix_qmmm.html
 "path-integral molecular dynamics (PIMD)"_fix_ipi.html and "this as well"_fix_pimd.html
-Monte Carlo via "GCMC"_fix_gcmc.html and "tfMC"_fix_tfmc.html and "atom swapping"_fix_swap.html
+Monte Carlo via "GCMC"_fix_gcmc.html and "tfMC"_fix_tfmc.html "atom swapping"_fix_atom_swap.html and "bond swapping"_fix_bond_swap.html
 "Direct Simulation Monte Carlo"_pair_dsmc.html for low-density fluids
 "Peridynamics mesoscale modeling"_pair_peri.html
 "Lattice Boltzmann fluid"_fix_lb_fluid.html

--- a/doc/src/Section_packages.txt
+++ b/doc/src/Section_packages.txt
@@ -795,7 +795,7 @@ Supporting info:
 "doc/PDF/PDLammps_overview.pdf"_PDF/PDLammps_overview.pdf,
 "doc/PDF/PDLammps_EPS.pdf"_PDF/PDLammps_EPS.pdf,
 "doc/PDF/PDLammps_VES.pdf"_PDF/PDLammps_VES.pdf, "atom_style
-peri"_atom_style.html, "compute damage"_compute_damage.html,
+peri"_atom_style.html, "compute damage/atom"_compute_damage_atom.html,
 "pair_style peri/pmb"_pair_peri.html, examples/peri
  
 :line
@@ -846,9 +846,8 @@ PYTHON package :link(PYTHON),h5
 Contents: A "python"_python.html command which allow you to execute
 Python code from a LAMMPS input script.  The code can be in a separate
 file or embedded in the input script itself.  See "Section python
-11.2"_Section_python.html#py_2" for an overview of using Python from
-LAMMPS and "Section python"_Section_python.html" for other ways to use
-LAMMPS and Python together.
+11.2"_Section_python.html" for an overview of using Python from
+LAMMPS and for other ways to use LAMMPS and Python together.
 
 Building with the PYTHON package assumes you have a Python shared
 library available on your system, which needs to be a Python 2
@@ -1003,7 +1002,7 @@ make machine :pre
 Make.py -p ^rigid -a machine :pre
 
 Supporting info: "compute erotate/rigid"_compute_erotate_rigid.html,
-"fix shake"_fix_shake.html, "fix rattle"_fix_rattle.html, "fix
+"fix shake"_fix_shake.html, "fix rattle"_fix_shake.html, "fix
 rigid/*"_fix_rigid.html, examples/ASPHERE, examples/rigid
 
 :line
@@ -1055,8 +1054,8 @@ make machine :pre
 Make.py -p ^snap -a machine :pre
 
 Supporting info: "pair snap"_pair_snap.html, "compute
-sna/atom"_compute_sna_atom.html, "compute snad/atom"_compute_sna.html,
-"compute snav/atom"_compute_sna.html, examples/snap
+sna/atom"_compute_sna_atom.html, "compute snad/atom"_compute_sna_atom.html,
+"compute snav/atom"_compute_sna_atom.html, examples/snap
  
 :line
  
@@ -1164,8 +1163,8 @@ Package, Description, Author(s), Doc page, Example, Pic/movie, Library
 "USER-SMD"_#USER-SMD, smoothed Mach dynamics, Georg Ganzenmuller (EMI), "userguide.pdf"_PDF/SMD_LAMMPS_userguide.pdf, USER/smd, -, -
 "USER-SMTBQ"_#USER-SMTBQ, Second Moment Tight Binding - QEq potential, Salles & Maras & Politano & Tetot (4), "pair_style smtbq"_pair_smtbq.html, USER/smtbq, -, -
 "USER-SPH"_#USER-SPH, smoothed particle hydrodynamics, Georg Ganzenmuller (EMI), "userguide.pdf"_PDF/SPH_LAMMPS_userguide.pdf, USER/sph, "sph"_sph, -
-"USER-TALLY"_#USER-TALLY, Pairwise tallied computes, Axel Kohlmeyer (Temple U), "compute <...>/tally"_compute_tally.html, USER/tally, -, -
-"USER-VTK"_#USER-VTK, VTK-style dumps, Berger and Queteschiner (6), "compute custom/vtk"_compute_custom_vtk.html, -, -, lib/vtk
+"USER-TALLY"_#USER-TALLY, Pairwise tallied computes, Axel Kohlmeyer (Temple U), "compute XXX/tally"_compute_tally.html, USER/tally, -, -
+"USER-VTK"_#USER-VTK, VTK-style dumps, Berger and Queteschiner (6), "compute custom/vtk"_dump_custom_vtk.html, -, -, lib/vtk
 :tb(ea=c)
 
 :link(atc,http://lammps.sandia.gov/pictures.html#atc)
@@ -1260,7 +1259,7 @@ calculation.  See src/USER-AWPMD/README for more details.
 To build LAMMPS with this package ...
 
 Supporting info: src/USER-AWPMD/README, "fix
-awpmd/cut"_pair_awpmd_cut.html, examples/USER/awpmd
+awpmd/cut"_pair_awpmd.html, examples/USER/awpmd
 
 Author: Ilya Valuev at the JIHT in Russia (valuev at
 physik.hu-berlin.de).  Contact him directly if you have questions.
@@ -1315,7 +1314,7 @@ kinematic diffraction theory.  See src/USER-DIFFRACTION/README for
 more details.
 
 Supporting info: "compute saed"_compute_saed.html, "compute
-xrd"_compute_xrd.html, "fix saed.vtk"_fix_saed_vtk.html,
+xrd"_compute_xrd.html, "fix saed/vtk"_fix_saed_vtk.html,
 examples/USER/diffraction
 
 Author: Shawn P. Coleman (shawn.p.coleman8.ctr at mail.mil) while at
@@ -1337,10 +1336,11 @@ splitting algorithm.  See src/USER-DPD/README for more details.
 Supporting info: /src/USER-DPD/README, "compute dpd"_compute_dpd.html
 "compute dpd/atom"_compute_dpd_atom.html
 "fix eos/cv"_fix_eos_table.html "fix eos/table"_fix_eos_table.html
-"fix shardlow"_fix_shardlow.html
-"pair_dpd/conservative"_pair_dpd_conservative.html
-"pair_dpd/fdt"_pair_dpd_fdt.html
-"pair_dpd/fdt/energy"_pair_dpd_fdt.html, examples/USER/dpd
+ "fix eos/table/rx"_fix_eos_table_rx.html "fix shardlow"_fix_shardlow.html
+"fix rx"_fix_rx.html "pair table/rx"_pair_table_rx.html
+"pair dpd/fdt"_pair_dpd_fdt.html "pair dpd/fdt/energy"_pair_dpd_fdt.html
+"pair exp6/rx"_pair_exp6_rx.html "pair multi/lucy"_pair_multi_lucy.html
+"pair multi/lucy/rx"_pair_multi_lucy_rx.html, examples/USER/dpd
 
 Authors: James Larentzos (ARL) (james.p.larentzos.civ at mail.mil),
 Timothy Mattox (Engility Corp) (Timothy.Mattox at engilitycorp.com)
@@ -1440,7 +1440,7 @@ Phi-enabled styles.
 
 Supporting info: examples/accelerate, src/USER-INTEL/TEST
 
-"Section_accelerate"_Section_accelerate.html#acc_9
+"Section_accelerate"_Section_accelerate.html#acc_3
 
 Author: Mike Brown at Intel (michael.w.brown at intel.com).  Contact
 him directly if you have questions.
@@ -1592,7 +1592,7 @@ application itself.
 
 See this doc page to get started:
 
-"dump molfile"_dump_molfile.html#acc_5
+"dump molfile"_dump_molfile.html
 
 The person who created this package is Axel Kohlmeyer at Temple U
 (akohlmey at gmail.com).  Contact him directly if you have questions.
@@ -1609,7 +1609,7 @@ styles, and fix styles.
  
 See this section of the manual to get started:
 
-"Section_accelerate"_Section_accelerate.html#acc_5
+"Section_accelerate"_Section_accelerate.html#acc_3
 
 The person who created this package is Axel Kohlmeyer at Temple U
 (akohlmey at gmail.com).  Contact him directly if you have questions.

--- a/doc/src/Section_start.txt
+++ b/doc/src/Section_start.txt
@@ -1353,7 +1353,7 @@ Note that the keywords do not use a leading minus sign.  I.e. the
 keyword is "t", not "-t".  Also note that each of the keywords has a
 default setting.  Example of when to use these options and what
 settings to use on different platforms is given in "Section
-5.8"_Section_accelerate.html#acc_8.
+5.8"_Section_accelerate.html#acc_3.
 
 d or device
 g or gpus

--- a/doc/src/accelerate_kokkos.txt
+++ b/doc/src/accelerate_kokkos.txt
@@ -246,7 +246,7 @@ used if running with KOKKOS_DEVICES=Pthreads for pthreads.  It is not
 necessary for KOKKOS_DEVICES=OpenMP for OpenMP, because OpenMP
 provides alternative methods via environment variables for binding
 threads to hardware cores.  More info on binding threads to cores is
-given in "this section"_Section_accelerate.html#acc_8.
+given in "this section"_Section_accelerate.html#acc_3.
 
 KOKKOS_ARCH=KNC enables compiler switches needed when compling for an
 Intel Phi processor.

--- a/doc/src/compute_damage_atom.txt
+++ b/doc/src/compute_damage_atom.txt
@@ -57,7 +57,7 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 
-"compute dilatation"_compute_dilatation.html, "compute
-plasticity"_compute_plasticity.html
+"compute dilatation/atom"_compute_dilatation_atom.html,
+"compute plasticity/atom"_compute_plasticity_atom.html
 
 [Default:] none

--- a/doc/src/compute_dilatation_atom.txt
+++ b/doc/src/compute_dilatation_atom.txt
@@ -60,7 +60,7 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 
-"compute damage"_compute_damage.html, "compute
-plasticity"_compute_plasticity.html
+"compute damage/atom"_compute_damage_atom.html,
+"compute plasticity/atom"_compute_plasticity_atom.html
 
 [Default:] none 

--- a/doc/src/compute_erotate_rigid.txt
+++ b/doc/src/compute_erotate_rigid.txt
@@ -56,6 +56,6 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 
-"compute ke/rigid"_compute_erotate_ke_rigid.html
+"compute ke/rigid"_compute_ke_rigid.html
 
 [Default:] none

--- a/doc/src/compute_plasticity_atom.txt
+++ b/doc/src/compute_plasticity_atom.txt
@@ -54,8 +54,8 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 
-"compute damage"_compute_damage.html, "compute
-dilatation"_compute_dilatation.html
+"compute damage/atom"_compute_damage_atom.html,
+"compute dilatation/atom"_compute_dilatation_atom.html
 
 [Default:] none 
 

--- a/doc/src/compute_reduce.txt
+++ b/doc/src/compute_reduce.txt
@@ -93,7 +93,7 @@ means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 compute reduce commands are
-equivalent, since the "compute stress/atom"_compute_stress/atom.html
+equivalent, since the "compute stress/atom"_compute_stress_atom.html
 command creates a per-atom array with 6 columns:
 
 compute myPress all stress/atom NULL

--- a/doc/src/compute_temp_deform_eff.txt
+++ b/doc/src/compute_temp_deform_eff.txt
@@ -26,12 +26,12 @@ nuclei and electrons in the "electron force field"_pair_eff.html
 model, after subtracting out a streaming velocity induced by the
 simulation box changing size and/or shape, for example in a
 non-equilibrium MD (NEMD) simulation.  The size/shape change is
-induced by use of the "fix deform/eff"_fix_deform_eff.html command.  A
+induced by use of the "fix deform"_fix_deform.html command.  A
 compute of this style is created by the "fix
 nvt/sllod/eff"_fix_nvt_sllod_eff.html command to compute the thermal
 temperature of atoms for thermostatting purposes.  A compute of this
 style can also be used by any command that computes a temperature,
-e.g. "thermo_modify"_thermo_modify.html, "fix npt/eff"_fix_nh.html,
+e.g. "thermo_modify"_thermo_modify.html, "fix npt/eff"_fix_nh_eff.html,
 etc.
 
 The calculation performed by this compute is exactly like that
@@ -66,8 +66,7 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 
-"compute temp/ramp"_compute_temp_ramp.html, "fix
-deform/eff"_fix_deform_eff.html, "fix
-nvt/sllod/eff"_fix_nvt_sllod_eff.html
+"compute temp/ramp"_compute_temp_ramp.html, "fix deform"_fix_deform.html,
+"fix nvt/sllod/eff"_fix_nvt_sllod_eff.html
 
 [Default:] none

--- a/doc/src/compute_temp_eff.txt
+++ b/doc/src/compute_temp_eff.txt
@@ -26,7 +26,7 @@ Define a computation that calculates the temperature of a group of
 nuclei and electrons in the "electron force field"_pair_eff.html
 model.  A compute of this style can be used by commands that compute a
 temperature, e.g. "thermo_modify"_thermo_modify.html, "fix
-npt/eff"_fix_npt_eff.html, etc.
+npt/eff"_fix_nh_eff.html, etc.
 
 The temperature is calculated by the formula KE = dim/2 N k T, where
 KE = total kinetic energy of the group of atoms (sum of 1/2 m v^2 for

--- a/doc/src/dihedral_table.txt
+++ b/doc/src/dihedral_table.txt
@@ -195,7 +195,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-USER-MISC package.  See the "Making LAMMPS"_Section_start.html#2_3
+USER-MISC package.  See the "Making LAMMPS"_Section_start.html#start_3
 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/dump.txt
+++ b/doc/src/dump.txt
@@ -441,7 +441,7 @@ from m to n (inclusive).
 
 Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 dump commands are
-equivalent, since the "compute stress/atom"_compute_stress/atom.html
+equivalent, since the "compute stress/atom"_compute_stress_atom.html
 command creates a per-atom array with 6 columns:
 
 compute myPress all stress/atom NULL

--- a/doc/src/dump_custom_vtk.txt
+++ b/doc/src/dump_custom_vtk.txt
@@ -34,7 +34,7 @@ args = list of arguments for a particular style :l
       proc = ID of processor that owns atom
       procp1 = ID+1 of processor that owns atom
       type = atom type
-      element = name of atom element, as defined by "dump_modify"_dump_modify_vtk.html command
+      element = name of atom element, as defined by "dump_modify"_dump_modify.html command
       mass = atom mass
       x,y,z = unscaled atom coordinates
       xs,ys,zs = scaled atom coordinates
@@ -71,7 +71,7 @@ for the XML format; see the "VTK
 homepage"_http://www.vtk.org/VTK/img/file-formats.pdf for a detailed
 description of these formats.  Since this naming convention conflicts
 with the way binary output is usually specified (see below),
-"dump_modify binary"_dump_modify_vtk.html allows to set the binary
+"dump_modify binary"_dump_modify.html allows to set the binary
 flag for this dump style explicitly.
 
 [Description:]
@@ -81,10 +81,10 @@ timesteps in a format readable by the "VTK visualization
 toolkit"_http://www.vtk.org or other visualization tools that use it,
 e.g. "ParaView"_http://www.paraview.org.  The timesteps on which dump
 output is written can also be controlled by a variable; see the
-"dump_modify every"_dump_modify_vtk.html command for details.
+"dump_modify every"_dump_modify.html command for details.
 
 Only information for atoms in the specified group is dumped.  The
-"dump_modify thresh and region"_dump_modify_vtk.html commands can also
+"dump_modify thresh and region"_dump_modify.html commands can also
 alter what atoms are included; see details below.
 
 As described below, special characters ("*", "%") in the filename
@@ -95,7 +95,7 @@ on timesteps when neighbor lists are rebuilt, the coordinates of an
 atom written to a dump file may be slightly outside the simulation
 box.
 
-IMPORTANT NOTE: Unless the "dump_modify sort"_dump_modify_vtk.html
+IMPORTANT NOTE: Unless the "dump_modify sort"_dump_modify.html
 option is invoked, the lines of atom information written to dump files
 will be in an indeterminate order for each snapshot.  This is even
 true when running on a single processor, if the "atom_modify
@@ -106,7 +106,7 @@ data for a single snapshot is collected from multiple processors, each
 of which owns a subset of the atoms.
 
 For the {custom/vtk} style, sorting is off by default. See the
-"dump_modify"_dump_modify_vtk.html doc page for details.
+"dump_modify"_dump_modify.html doc page for details.
 
 :line
 
@@ -148,21 +148,21 @@ timestep 0) and on the last timestep of a minimization if the
 minimization converges.  Note that this means a dump will not be
 performed on the initial timestep after the dump command is invoked,
 if the current timestep is not a multiple of N.  This behavior can be
-changed via the "dump_modify first"_dump_modify_vtk.html command, which
+changed via the "dump_modify first"_dump_modify.html command, which
 can also be useful if the dump command is invoked after a minimization
 ended on an arbitrary timestep.  N can be changed between runs by
-using the "dump_modify every"_dump_modify_vtk.html command.
-The "dump_modify every"_dump_modify_vtk.html command
+using the "dump_modify every"_dump_modify.html command.
+The "dump_modify every"_dump_modify.html command
 also allows a variable to be used to determine the sequence of
 timesteps on which dump files are written.  In this mode a dump on the
 first timestep of a run will also not be written unless the
-"dump_modify first"_dump_modify_vtk.html command is used.
+"dump_modify first"_dump_modify.html command is used.
 
 Dump filenames can contain two wildcard characters.  If a "*"
 character appears in the filename, then one file per snapshot is
 written and the "*" character is replaced with the timestep value.
 For example, tmp.dump*.vtk becomes tmp.dump0.vtk, tmp.dump10000.vtk,
-tmp.dump20000.vtk, etc.  Note that the "dump_modify pad"_dump_modify_vtk.html
+tmp.dump20000.vtk, etc.  Note that the "dump_modify pad"_dump_modify.html
 command can be used to insure all timestep numbers are the same length
 (e.g. 00010), which can make it easier to read a series of dump files
 in order with some post-processing tools.
@@ -176,7 +176,7 @@ mode of output on parallel machines that support parallel I/O for output.
 
 By default, P = the number of processors meaning one file per
 processor, but P can be set to a smaller value via the {nfile} or
-{fileper} keywords of the "dump_modify"_dump_modify_vtk.html command.
+{fileper} keywords of the "dump_modify"_dump_modify.html command.
 These options can be the most efficient way of writing out dump files
 when running on large numbers of processors.
 
@@ -202,7 +202,7 @@ The {id}, {mol}, {proc}, {procp1}, {type}, {element}, {mass}, {vx},
 {id} is the atom ID.  {mol} is the molecule ID, included in the data
 file for molecular systems.  {type} is the atom type.  {element} is
 typically the chemical name of an element, which you must assign to
-each type via the "dump_modify element"_dump_modify_vtk.html command.
+each type via the "dump_modify element"_dump_modify.html command.
 More generally, it can be any string you wish to associate with an
 atom type.  {mass} is the atom mass.  {vx}, {vy}, {vz}, {fx}, {fy},
 {fz}, and {q} are components of atom velocity and force and atomic

--- a/doc/src/fix_ave_chunk.txt
+++ b/doc/src/fix_ave_chunk.txt
@@ -141,7 +141,7 @@ means all indices from m to n (inclusive).
 Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 fix ave/chunk commands are
 equivalent, since the "compute
-property/atom"_compute_property/atom.html command creates, in this
+property/atom"_compute_property_atom.html command creates, in this
 case, a per-atom array with 3 columns:
 
 compute myAng all property/atom angmomx angmomy angmomz
@@ -150,7 +150,7 @@ fix 2 all ave/chunk 100 1 100 cc1 c_myAng\[1\] c_myAng\[2\] c_myAng\[3\] file tm
 
 NOTE: This fix works by creating an array of size {Nchunk} by Nvalues
 on each processor.  {Nchunk} is the number of chunks which is defined
-by the "compute chunk/atom"_doc/compute_chunk_atom.html command.
+by the "compute chunk/atom"_compute_chunk_atom.html command.
 Nvalues is the number of input values specified.  Each processor loops
 over its atoms, tallying its values to the appropriate chunk.  Then
 the entire array is summed across all processors.  This means that

--- a/doc/src/fix_bond_create.txt
+++ b/doc/src/fix_bond_create.txt
@@ -122,7 +122,7 @@ become one moleclue due to the created bond, all atoms in the new
 moleclue retain their original molecule IDs.
 
 If the {atype} keyword is used and if an angle potential is defined
-via the "angle_style"_angle.html command, then any new 3-body
+via the "angle_style"_angle_style.html command, then any new 3-body
 interactions inferred by the creation of a bond will create new angles
 of type {angletype}, with parameters assigned by the corresponding
 "angle_coeff"_angle_coeff.html command.  Likewise, the {dtype} and

--- a/doc/src/fix_deform.txt
+++ b/doc/src/fix_deform.txt
@@ -487,7 +487,7 @@ NOTE: For non-equilibrium MD (NEMD) simulations using "remap v" it is
 usually desirable that the fluid (or flowing material, e.g. granular
 particles) stream with a velocity profile consistent with the
 deforming box.  As mentioned above, using a thermostat such as "fix
-nvt/sllod"_fix_nvt_sllod.html or "fix lavgevin"_doc/fix_langevin.html
+nvt/sllod"_fix_nvt_sllod.html or "fix lavgevin"_fix_langevin.html
 (with a bias provided by "compute
 temp/deform"_compute_temp_deform.html), will typically accomplish
 that.  If you do not use a thermostat, then there is no driving force

--- a/doc/src/fix_deposit.txt
+++ b/doc/src/fix_deposit.txt
@@ -147,7 +147,7 @@ the list of relative probabilities.  The N values must sum to 1.0.
 
 If you wish to insert molecules via the {mol} keyword, that will be
 treated as rigid bodies, use the {rigid} keyword, specifying as its
-value the ID of a separate "fix rigid/small"_fix_rigid_small.html
+value the ID of a separate "fix rigid/small"_fix_rigid.html
 command which also appears in your input script.
 
 If you wish to insert molecules via the {mol} keyword, that will have

--- a/doc/src/fix_ehex.txt
+++ b/doc/src/fix_ehex.txt
@@ -111,7 +111,7 @@ the keyword {hex} is specified.
 [Compatibility with SHAKE and RATTLE (rigid molecules)]:
 
 This fix is compatible with "fix shake"_fix_shake.html and "fix
-rattle"_fix_rattle.html. If either of these constraining algorithms is
+rattle"_fix_shake.html. If either of these constraining algorithms is
 specified in the input script and the keyword {constrain} is set, the
 bond distances will be corrected a second time at the end of the
 integration step.  It is recommended to specify the keyword {com} in
@@ -124,7 +124,7 @@ rescaling takes place if the centre of mass lies outside the region.
 NOTE: You can only use the keyword {com} along with {constrain}.
 
 To achieve the highest accuracy it is recommended to use "fix
-rattle"_fix_rattle.html with the keywords {constrain} and {com} as
+rattle"_fix_shake.html with the keywords {constrain} and {com} as
 shown in the second example. Only if RATTLE is employed, the velocity
 constraints will be satisfied.
 

--- a/doc/src/fix_eos_table.txt
+++ b/doc/src/fix_eos_table.txt
@@ -71,7 +71,7 @@ initial text must match the argument specified in the fix command.
 The next line lists the number of table entries.  The parameter "N" is
 required and its value is the number of table entries that follow.
 Note that this may be different than the {N} specified in the "fix
-eos/table"_fix_style.html command.  Let Ntable = {N} in the fix
+eos/table"_fix_eos_table.html command.  Let Ntable = {N} in the fix
 command, and Nfile = "N" in the tabulated file.  What LAMMPS does is a
 preliminary interpolation by creating splines using the Nfile
 tabulated values as nodal points.  It uses these to interpolate as
@@ -112,6 +112,6 @@ are not within the table cutoffs.
 
 [Related commands:]
 
-"fix shardlow"_fix_shardlow.html, "pair dpd/fdt"_dpd_fdt.html
+"fix shardlow"_fix_shardlow.html, "pair dpd/fdt"_pair_dpd_fdt.html
 
 [Default:] none

--- a/doc/src/fix_eos_table_rx.txt
+++ b/doc/src/fix_eos_table_rx.txt
@@ -135,7 +135,7 @@ are not within the table cutoffs.
 [Related commands:]
 
 "fix rx"_fix_rx.html,
-"pair dpd/fdt"_dpd_fdt.html
+"pair dpd/fdt"_pair_dpd_fdt.html
 
 [Default:] none
 

--- a/doc/src/fix_lb_momentum.txt
+++ b/doc/src/fix_lb_momentum.txt
@@ -50,7 +50,7 @@ No information about this fix is written to "binary restart
 files"_restart.html.  None of the "fix_modify"_fix_modify.html options
 are relevant to this fix.  No global or per-atom quantities are stored
 by this fix for access by various "output
-commands"_Section_howto.html#4_15.  No parameter of this fix can be
+commands"_Section_howto.html#howto_15.  No parameter of this fix can be
 used with the {start/stop} keywords of the "run"_run.html command.
 This fix is not invoked during "energy minimization"_minimize.html.
 

--- a/doc/src/fix_lb_pc.txt
+++ b/doc/src/fix_lb_pc.txt
@@ -35,7 +35,7 @@ No information about this fix is written to "binary restart
 files"_restart.html.  None of the "fix_modify"_fix_modify.html options
 are relevant to this fix.  No global or per-atom quantities are stored
 by this fix for access by various "output
-commands"_Section_howto.html#4_15.  No parameter of this fix can be
+commands"_Section_howto.html#howto_15.  No parameter of this fix can be
 used with the {start/stop} keywords of the "run"_run.html command.
 This fix is not invoked during "energy minimization"_minimize.html.
 

--- a/doc/src/fix_nh_eff.txt
+++ b/doc/src/fix_nh_eff.txt
@@ -75,7 +75,7 @@ doc page), are performed with computes that include the eFF contribution
 to the temperature or kinetic energy from the electron radial velocity.
 
 NOTE: there are two different pressures that can be reported for eFF
-when defining the pair_style (see "pair eff/cut"_pair_eff_cut.html to
+when defining the pair_style (see "pair eff/cut"_pair_eff.html to
 understand these settings), one (default) that considers electrons do
 not contribute radial virial components (i.e. electrons treated as
 incompressible 'rigid' spheres) and one that does.  The radial

--- a/doc/src/fix_phonon.txt
+++ b/doc/src/fix_phonon.txt
@@ -148,7 +148,7 @@ fix. You can use it to change the temperature compute from thermo_temp
 to the one that reflects the true temperature of atoms in the group.
 
 No global scalar or vector or per-atom quantities are stored by this
-fix for access by various "output commands"_Section_howto.html#4_15.
+fix for access by various "output commands"_Section_howto.html#howto_15.
 
 Instead, this fix outputs its initialization information (including
 mapping information) and the calculated dynamical matrices to the file

--- a/doc/src/fix_pour.txt
+++ b/doc/src/fix_pour.txt
@@ -114,7 +114,7 @@ the list of relative probabilities.  The N values must sum to 1.0.
 
 If you wish to insert molecules via the {mol} keyword, that will be
 treated as rigid bodies, use the {rigid} keyword, specifying as its
-value the ID of a separate "fix rigid/small"_fix_rigid_small.html
+value the ID of a separate "fix rigid/small"_fix_rigid.html
 command which also appears in your input script.
 
 If you wish to insert molecules via the {mol} keyword, that will have

--- a/doc/src/fix_reax_bonds.txt
+++ b/doc/src/fix_reax_bonds.txt
@@ -31,7 +31,7 @@ reax/c"_pair_reax_c.html in the exact same format as the original
 stand-alone ReaxFF code of Adri van Duin.  The bond information is
 written to {filename} on timesteps that are multiples of {Nevery},
 including timestep 0.  For time-averaged chemical species analysis,
-please see the "fix species"_fix_species.html command.
+please see the "fix reaxc/c/species"_fix_reaxc_species.html command.
 
 The format of the output file should be self-explantory.
 

--- a/doc/src/fix_rx.txt
+++ b/doc/src/fix_rx.txt
@@ -198,6 +198,6 @@ enthalpy DPD simulation.
 
 "fix eos/table/rx"_fix_eos_table_rx.html,
 "fix shardlow"_fix_shardlow.html,
-"pair dpd/fdt/energy"_dpd_fdt_energy.html
+"pair dpd/fdt/energy"_pair_dpd_fdt.html
 
 [Default:] none

--- a/doc/src/fix_shardlow.txt
+++ b/doc/src/fix_shardlow.txt
@@ -26,7 +26,7 @@ integrate the DPD equations of motion.  The SSA splits the integration
 into a stochastic and deterministic integration step.  The fix
 {shardlow} performs the stochastic integration step and must be used
 in conjunction with a deterministic integrator (e.g. "fix
-nve"_fix_nve.html or "fix nph"_fix_nph.html).  The stochastic
+nve"_fix_nve.html or "fix nph"_fix_nh.html).  The stochastic
 integration of the dissipative and random forces is performed prior to
 the deterministic integration of the conservative force. Further
 details regarding the method are provided in "(Lisal)"_#Lisal and

--- a/doc/src/fix_smd.txt
+++ b/doc/src/fix_smd.txt
@@ -138,14 +138,14 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 :line
 
-:link(Israilev)
+:link(Izrailev)
 [(Izrailev)] Izrailev, Stepaniants, Isralewitz, Kosztin, Lu, Molnar,
 Wriggers, Schulten. Computational Molecular Dynamics: Challenges,
 Methods, Ideas, volume 4 of Lecture Notes in Computational Science and
 Engineering, pp. 39-65. Springer-Verlag, Berlin, 1998.
 
-[(Park)]
-Park, Schulten, J. Chem. Phys. 120 (13), 5946 (2004)
+:link(Park)
+[(Park)] Park, Schulten, J. Chem. Phys. 120 (13), 5946 (2004)
 
-[(Jarzynski)]
-Jarzynski, Phys. Rev. Lett. 78, 2690 (1997)
+:link(Jarzynski)
+[(Jarzynski)] Jarzynski, Phys. Rev. Lett. 78, 2690 (1997)

--- a/doc/src/fix_wall_piston.txt
+++ b/doc/src/fix_wall_piston.txt
@@ -92,7 +92,7 @@ No information about this fix is written to "binary restart
 files"_restart.html.  None of the "fix_modify"_fix_modify.html options
 are relevant to this fix.  No global or per-atom quantities are stored
 by this fix for access by various "output
-commands"_Section_howto.html#howoto_15.  No parameter of this fix can
+commands"_Section_howto.html#howto_15.  No parameter of this fix can
 be used with the {start/stop} keywords of the "run"_run.html command.
 This fix is not invoked during "energy minimization"_minimize.html.
 

--- a/doc/src/kspace_style.txt
+++ b/doc/src/kspace_style.txt
@@ -74,7 +74,7 @@ interacts with charges in an infinite array of periodic images of the
 simulation domain.
 
 Note that using a long-range solver requires use of a matching "pair
-style"_pair.html to perform consistent short-range pairwise
+style"_pair_style.html to perform consistent short-range pairwise
 calculations.  This means that the name of the pair style contains a
 matching keyword to the name of the KSpace style, as in this table:
 

--- a/doc/src/molecule.txt
+++ b/doc/src/molecule.txt
@@ -184,7 +184,7 @@ NOTE: Whether a section is required depends on how the molecule
 template is used by other LAMMPS commands.  For example, to add a
 molecule via the "fix deposit"_fix_deposit.html command, the Coords
 and Types sections are required.  To add a rigid body via the "fix
-pour"_fix_pout.html command, the Bonds (Angles, etc) sections are not
+pour"_fix_pour.html command, the Bonds (Angles, etc) sections are not
 required, since the molecule will be treated as a rigid body.  Some
 sections are optional.  For example, the "fix pour"_fix_pour.html
 command can be used to add "molecules" which are clusters of

--- a/doc/src/neighbor.txt
+++ b/doc/src/neighbor.txt
@@ -73,7 +73,7 @@ section"_Section_start.html#start_8 for details.
 [Related commands:]
 
 "neigh_modify"_neigh_modify.html, "units"_units.html,
-"comm_modify"_cmom_modify.html
+"comm_modify"_comm_modify.html
 
 [Default:]
 

--- a/doc/src/pair_brownian.txt
+++ b/doc/src/pair_brownian.txt
@@ -123,7 +123,7 @@ This pair style can only be used via the {pair} keyword of the
 
 These styles are part of the COLLOID package.  They are only enabled
 if LAMMPS was built with that package.  See the "Making
-LAMMPS"_Section_start.html#2_3 section for more info.
+LAMMPS"_Section_start.html#start_3 section for more info.
 
 Only spherical monodisperse particles are allowed for pair_style
 brownian.

--- a/doc/src/pair_dipole.txt
+++ b/doc/src/pair_dipole.txt
@@ -138,19 +138,18 @@ dipole interactions.  The long-range portion is calculated by using
 computed at all.
 
 Atoms with dipole moments should be integrated using the "fix
-nve/sphere update dipole"_fix_nve_sphere.html command to rotate the
+nve/sphere update dipole"_fix_nve_sphere.html or the "fix
+nvt/sphere update dipole"_fix_nvt_sphere.html command to rotate the
 dipole moments.  The {omega} option on the "fix
 langevin"_fix_langevin.html command can be used to thermostat the
 rotational motion.  The "compute temp/sphere"_compute_temp_sphere.html
 command can be used to monitor the temperature, since it includes
 rotational degrees of freedom.  The "atom_style
-dipole"_atom_style.html command should be used since it defines the
-point dipoles and their rotational state.  The magnitude of the dipole
-moment for each type of particle can be defined by the
-"dipole"_dipole.html command or in the "Dipoles" section of the data
-file read in by the "read_data"_read_data.html command.  Their initial
-orientation can be defined by the "set dipole"_set.html command or in
-the "Atoms" section of the data file.
+hybrid dipole sphere"_atom_style.html command should be used since
+it defines the point dipoles and their rotational state.
+The magnitude and orientation of the dipole moment for each particle
+can be defined by the "set"_set.html command or in the "Atoms" section
+of the data file read in by the "read_data"_read_data.html command.
 
 The following coefficients must be defined for each pair of atoms
 types via the "pair_coeff"_pair_coeff.html command as in the examples
@@ -242,7 +241,8 @@ currently supported.
 
 [Related commands:]
 
-"pair_coeff"_pair_coeff.html
+"pair_coeff"_pair_coeff.html, "set"_set.html, "read_data"_read_data.html,
+"fix nve/sphere"_fix_nve_sphere.html, "fix nvt/sphere"_fix_nvt_sphere.html
 
 [Default:] none
 

--- a/doc/src/pair_dpd_fdt.txt
+++ b/doc/src/pair_dpd_fdt.txt
@@ -115,7 +115,7 @@ enabled if LAMMPS was built with that package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info.
 
 Pair styles {dpd/fdt} and {dpd/fdt/energy} require use of the
-"communicate vel yes"_communicate.html option so that velocites are
+"comm_modify vel yes"_comm_modify.html option so that velocites are
 stored by ghost atoms.
 
 Pair style {dpd/fdt/energy} requires "atom_style dpd"_atom_style.html

--- a/doc/src/pair_gayberne.txt
+++ b/doc/src/pair_gayberne.txt
@@ -191,7 +191,7 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 These pair style require that atoms store torque and a quaternion to
 represent their orientation, as defined by the
 "atom_style"_atom_style.html.  It also require they store a per-type
-"shape"_shape.html.  The particles cannot store a per-particle
+"shape"_set.html.  The particles cannot store a per-particle
 diameter.
 
 This pair style requires that atoms be ellipsoids as defined by the

--- a/doc/src/pair_line_lj.txt
+++ b/doc/src/pair_line_lj.txt
@@ -131,7 +131,7 @@ This pair style can only be used via the {pair} keyword of the
 
 This style is part of the ASPHERE package.  It is only enabled if
 LAMMPS was built with that package.  See the "Making
-LAMMPS"_Section_start.html#2_3 section for more info.
+LAMMPS"_Section_start.html#start_3 section for more info.
 
 Defining particles to be line segments so they participate in
 line/line or line/particle interactions requires the use the

--- a/doc/src/pair_thole.txt
+++ b/doc/src/pair_thole.txt
@@ -60,7 +60,7 @@ it also allows for mixing pair coefficients instead of listing them all.
 The {lj/cut/thole/long} pair style is also a bit faster because it avoids an
 overlay and can benefit from OMP acceleration. Moreover, it uses a more
 precise approximation of the direct Coulomb interaction at short range similar
-to "coul/long/cs"_pair_coul_long_cs.html, which stabilizes the temperature of
+to "coul/long/cs"_pair_cs.html, which stabilizes the temperature of
 Drude particles.
 
 The {thole} pair styles compute the Coulomb interaction damped at

--- a/doc/src/pair_tri_lj.txt
+++ b/doc/src/pair_tri_lj.txt
@@ -102,7 +102,7 @@ This pair style can only be used via the {pair} keyword of the
 
 This style is part of the ASPHERE package.  It is only enabled if
 LAMMPS was built with that package.  See the "Making
-LAMMPS"_Section_start.html#2_3 section for more info.
+LAMMPS"_Section_start.html#start_3 section for more info.
 
 Defining particles to be triangles so they participate in tri/tri or
 tri/particle interactions requires the use the "atom_style

--- a/doc/src/python.txt
+++ b/doc/src/python.txt
@@ -460,7 +460,7 @@ your Python function must be able to to load the Python module in
 python/lammps.py that wraps the LAMMPS library interface.  These are
 the same steps required to use Python by itself to wrap LAMMPS.
 Details on these steps are explained in "Section
-python"_Section.python.html.  Note that it is important that the
+python"_Section_python.html.  Note that it is important that the
 stand-alone LAMMPS executable and the LAMMPS shared library be
 consistent (built from the same source code files) in order for this
 to work.  If the two have been built at different times using

--- a/doc/src/rerun.txt
+++ b/doc/src/rerun.txt
@@ -53,7 +53,7 @@ Compute the energy and forces of snaphots using a different potential.
 Calculate one or more diagnostic quantities on the snapshots that
 weren't computed in the initial run.  These can also be computed with
 settings not used in the initial run, e.g. computing an RDF via the
-"compute rdf"_compute.rdf.html command with a longer cutoff than was
+"compute rdf"_compute_rdf.html command with a longer cutoff than was
 used initially. :l
 
 Calculate the portion of per-atom forces resulting from a subset of

--- a/doc/src/variable.txt
+++ b/doc/src/variable.txt
@@ -1108,7 +1108,7 @@ with a leading $ sign (e.g. $x or $\{abc\}) versus with a leading "v_"
 command, including a variable command.  The input script parser
 evaluates the reference variable immediately and substitutes its value
 into the command.  As explained in "Section commands
-3.2"_Section_commands.html#3_2 for "Parsing rules", you can also use
+3.2"_Section_commands.html#cmd_2 for "Parsing rules", you can also use
 un-named "immediate" variables for this purpose.  For example, a
 string like this $((xlo+xhi)/2+sqrt(v_area)) in an input script
 command evaluates the string between the parenthesis as an equal-style


### PR DESCRIPTION
This PR corrects broken links in the documentation as indicated through warnings when running sphinx to generate the html files. Updated html files are included as well.

NOTE: there are two references to files who seem to be part of code not yet added:
- fix_surface_global.txt
- pair_body_rounded_polygon.txt
