### PR TITLE
Extend is_available() function to query optional features

### DIFF
--- a/doc/html/variable.html
+++ b/doc/html/variable.html
@@ -965,11 +965,24 @@ if $(is_active(pair,respa)) then &quot;run_style respa 4 3 2 2  improper 1 inner
 <p>The <em>is_defined()</em> function allows to query categories like <em>compute</em>,
 <em>dump</em>, <em>fix</em>, <em>group</em>, <em>region</em>, and <em>variable</em> whether an entry
 with the provided name or id is defined.</p>
-<p>The <em>is_available()</em> function allows to query whether a specific
-optional feature is available, i.e. compiled in. This currently
-works for the following categories: <em>command</em>, <em>compute</em>, <em>fix</em>,
-and <em>pair_style</em>. For all categories except <em>command</em> also appending
-active suffixes is tried before reporting failure.</p>
+<p>The <em>is_available(category,name)</em> function allows to query whether
+a specific optional feature is available, i.e. compiled in.
+This currently works for the following categories: <em>command</em>,
+<em>compute</em>, <em>fix</em>, <em>pair_style</em> and <em>feature</em>. For all categories
+except <em>command</em> and <em>feature</em> also appending active suffixes is
+tried before reporting failure.</p>
+<p>The <em>feature</em> category is used to check the availability of compiled in
+features such as GZIP support, PNG support, JPEG support, FFMPEG support,
+and C++ exceptions for error handling. Corresponding values for name are
+<em>gzip</em>, <em>png</em>, <em>jpeg</em>, <em>ffmpeg</em> and <em>exceptions</em>.</p>
+<p>This enables writing input scripts which only dump using a given format if
+the compiled binary supports it.</p>
+<pre class="literal-block">
+if &quot;$(is_available(feature,png))&quot; then &quot;print 'PNG supported'&quot; else &quot;print 'PNG not supported'&quot;
+</pre>
+<pre class="literal-block">
+if &quot;$(is_available(feature,ffmpeg)&quot; then &quot;dump 3 all movie 25 movie.mp4 type type zoom 1.6 adiam 1.0&quot;
+</pre>
 </div>
 <hr class="docutils" />
 <div class="section" id="atom-values-and-vectors">

--- a/doc/src/variable.txt
+++ b/doc/src/variable.txt
@@ -894,11 +894,25 @@ The {is_defined()} function allows to query categories like {compute},
 {dump}, {fix}, {group}, {region}, and {variable} whether an entry
 with the provided name or id is defined.
 
-The {is_available()} function allows to query whether a specific
-optional feature is available, i.e. compiled in. This currently
-works for the following categories: {command}, {compute}, {fix},
-and {pair_style}. For all categories except {command} also appending
-active suffixes is tried before reporting failure.
+The {is_available(category,name)} function allows to query whether
+a specific optional feature is available, i.e. compiled in.
+This currently works for the following categories: {command},
+{compute}, {fix}, {pair_style} and {feature}. For all categories
+except {command} and {feature} also appending active suffixes is
+tried before reporting failure.
+
+The {feature} category is used to check the availability of compiled in
+features such as GZIP support, PNG support, JPEG support, FFMPEG support,
+and C++ exceptions for error handling. Corresponding values for name are
+{gzip}, {png}, {jpeg}, {ffmpeg} and {exceptions}.
+
+This enables writing input scripts which only dump using a given format if
+the compiled binary supports it.
+
+if "$(is_available(feature,png))" then "print 'PNG supported'" else "print 'PNG not supported'" :pre
+
+if "$(is_available(feature,ffmpeg)" then "dump 3 all movie 25 movie.mp4 type type zoom 1.6 adiam 1.0" :pre
+
 
 :line
 

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -925,6 +925,18 @@ bool Info::is_available(const char *category, const char *name)
         delete[] name_w_suffix;
       }
     }
+  } else if (strcmp(category,"feature") == 0) {
+    if (strcmp(name,"gzip") == 0) {
+      return has_gzip_support();
+    } else if (strcmp(name,"png") == 0) {
+      return has_png_support();
+    } else if (strcmp(name,"jpeg") == 0) {
+      return has_jpeg_support();
+    } else if (strcmp(name,"ffmpeg") == 0) {
+      return has_ffmpeg_support();
+    } else if (strcmp(name,"exceptions") == 0) {
+      return has_exceptions();
+    }
   } else error->all(FLERR,"Unknown category for info is_available()");
 
   return match ? true : false;
@@ -1026,4 +1038,44 @@ static void print_columns(FILE* fp, vector<string> & styles)
       pos += 80;
     }
   }
+}
+
+bool Info::has_gzip_support() const {
+#ifdef LAMMPS_GZIP
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool Info::has_png_support() const {
+#ifdef LAMMPS_PNG
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool Info::has_jpeg_support() const {
+#ifdef LAMMPS_JPEG
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool Info::has_ffmpeg_support() const {
+#ifdef LAMMPS_FFMPEG
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool Info::has_exceptions() const {
+#ifdef LAMMPS_EXCEPTIONS
+  return true;
+#else
+  return false;
+#endif
 }

--- a/src/info.h
+++ b/src/info.h
@@ -33,6 +33,12 @@ class Info : protected Pointers {
   bool is_defined(const char *, const char *);
   bool is_available(const char *, const char *);
 
+  bool has_gzip_support() const;
+  bool has_png_support() const;
+  bool has_jpeg_support() const;
+  bool has_ffmpeg_support() const;
+  bool has_exceptions() const;
+
 private:
   void available_styles(FILE * out, int flags);
 


### PR DESCRIPTION
This extends the `is_available` function with a `feature` category, which allows to query if PNG, JPEG, FFMPEG, GZIP support and C++ exceptions were compiled into the binary.

Adding this enables input scripts which optionally use these features:

``` bash
if "$(is_available(feature,png))" then "print 'PNG supported'"

if "$(is_available(feature,ffmpeg)" then &
   "dump 3 all movie 25 movie.mp4 type type zoom 1.6 adiam 1.0"
```
