### PR TITLE
consolidate ignoring python bytecompiled cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 *.x
 *.exe
 *.dll
+*.pyc
+__pycache__
 
 Obj_*
 log.lammps
@@ -20,6 +22,8 @@ log.cite
 *.orig
 *.rej
 .vagrant
+\#*#
+.#*
 
 .DS_Store
 .DS_Store?

--- a/doc/utils/converters/.gitignore
+++ b/doc/utils/converters/.gitignore
@@ -1,2 +1,1 @@
-__pycache__
 *.egg-info

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,3 +1,1 @@
-*.pyc
-__pycache__
-build
+/build


### PR DESCRIPTION
this moves the patterns for ignoring byte compiled python files into the toplevel .gitignore file and thus applies them globally.
