### PR TITLE
Eam fixes for scale

### DIFF
--- a/src/GPU/pair_eam_alloy_gpu.h
+++ b/src/GPU/pair_eam_alloy_gpu.h
@@ -33,6 +33,7 @@ public:
   void init_style();
   double single(int, int, int, int, double, double, double, double &);
   double memory_usage();
+  void *extract(const char *, int &) { return NULL; }
 
   int pack_forward_comm(int, int *, double *, int, int *);
   void unpack_forward_comm(int, int, double *);

--- a/src/GPU/pair_eam_fs_gpu.h
+++ b/src/GPU/pair_eam_fs_gpu.h
@@ -33,6 +33,7 @@ public:
   void init_style();
   double single(int, int, int, int, double, double, double, double &);
   double memory_usage();
+  void *extract(const char *, int &) { return NULL; }
 
   int pack_forward_comm(int, int *, double *, int, int *);
   void unpack_forward_comm(int, int, double *);

--- a/src/GPU/pair_eam_gpu.h
+++ b/src/GPU/pair_eam_gpu.h
@@ -34,6 +34,7 @@ class PairEAMGPU : public PairEAM {
   void init_style();
   double single(int, int, int, int, double, double, double, double &);
   double memory_usage();
+  void *extract(const char *, int &) { return NULL; }
 
   int pack_forward_comm(int, int *, double *, int, int *);
   void unpack_forward_comm(int, int, double *);

--- a/src/KOKKOS/pair_eam_alloy_kokkos.h
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.h
@@ -61,6 +61,7 @@ class PairEAMAlloyKokkos : public PairEAM {
   virtual ~PairEAMAlloyKokkos();
   virtual void compute(int, int);
   void init_style();
+  void *extract(const char *, int &) { return NULL; }
   void coeff(int, char **);
 
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_eam_fs_kokkos.h
+++ b/src/KOKKOS/pair_eam_fs_kokkos.h
@@ -61,6 +61,7 @@ class PairEAMFSKokkos : public PairEAM {
   virtual ~PairEAMFSKokkos();
   virtual void compute(int, int);
   void init_style();
+  void *extract(const char *, int &) { return NULL; }
   void coeff(int, char **);
 
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_eam_kokkos.h
+++ b/src/KOKKOS/pair_eam_kokkos.h
@@ -59,6 +59,7 @@ class PairEAMKokkos : public PairEAM {
   virtual ~PairEAMKokkos();
   virtual void compute(int, int);
   void init_style();
+  void *extract(const char *, int &) { return NULL; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairEAMPackForwardComm, const int&) const;

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -54,6 +54,7 @@ PairEAM::PairEAM(LAMMPS *lmp) : Pair(lmp)
   frho = NULL;
   rhor = NULL;
   z2r = NULL;
+  scale = NULL;
 
   frho_spline = NULL;
   rhor_spline = NULL;
@@ -232,6 +233,7 @@ void PairEAM::compute(int eflag, int vflag)
     if (eflag) {
       phi = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
       if (rho[i] > rhomax) phi += fp[i] * (rho[i]-rhomax);
+      phi *= scale[type[i]][type[i]];
       if (eflag_global) eng_vdwl += phi;
       if (eflag_atom) eatom[i] += phi;
     }
@@ -306,7 +308,7 @@ void PairEAM::compute(int eflag, int vflag)
           f[j][2] -= delz*fpair;
         }
 
-        if (eflag) evdwl = phi;
+        if (eflag) evdwl = scale[itype][jtype]*phi;
         if (evflag) ev_tally(i,j,nlocal,newton_pair,
                              evdwl,0.0,fpair,delx,dely,delz);
       }

--- a/src/MANYBODY/pair_eam.h
+++ b/src/MANYBODY/pair_eam.h
@@ -54,7 +54,7 @@ class PairEAM : public Pair {
   void init_style();
   double init_one(int, int);
   double single(int, int, int, int, double, double, double, double &);
-  void *extract(const char *, int &);
+  virtual void *extract(const char *, int &);
 
   virtual int pack_forward_comm(int, int *, double *, int, int *);
   virtual void unpack_forward_comm(int, int, double *);

--- a/src/OPT/pair_eam_opt.cpp
+++ b/src/OPT/pair_eam_opt.cpp
@@ -247,6 +247,7 @@ void PairEAMOpt::eval()
     if (EFLAG) {
       double phi = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
       if (rho[i] > rhomax) phi += fp[i] * (rho[i]-rhomax);
+      phi *= scale[type[i]][type[i]];
       if (eflag_global) eng_vdwl += phi;
       if (eflag_atom) eatom[i] += phi;
     }
@@ -273,6 +274,7 @@ void PairEAMOpt::eval()
     double tmpfz = 0.0;
 
     fast_gamma_t* _noalias tabssi = &tabss[itype1*ntypes*nr];
+    double* _noalias scale_i = scale[itype1+1]+1;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
@@ -316,12 +318,13 @@ void PairEAMOpt::eval()
         // psip needs both fp[i] and fp[j] terms since r_ij appears in two
         //   terms of embed eng: Fi(sum rho_ij) and Fj(sum rho_ji)
         //   hence embed' = Fi(sum rho_ij) rhojp + Fj(sum rho_ji) rhoip
+        // scale factor can be applied by thermodynamic integration
 
         double recip = 1.0/r;
         double phi = z2*recip;
         double phip = z2p*recip - phi*recip;
         double psip = fp[i]*rhojp + fp[j]*rhoip + phip;
-        double fpair = -psip*recip;
+        double fpair = -scale_i[jtype]*psip*recip;
 
         tmpfx += delx*fpair;
         tmpfy += dely*fpair;
@@ -332,7 +335,7 @@ void PairEAMOpt::eval()
           ff[j].z -= delz*fpair;
         }
 
-        if (EFLAG) evdwl = phi;
+        if (EFLAG) evdwl = scale_i[jtype]*phi;
 
         if (EVFLAG) ev_tally(i,j,nlocal,NEWTON_PAIR,
                              evdwl,0.0,fpair,delx,dely,delz);

--- a/src/USER-MISC/pair_cdeam.h
+++ b/src/USER-MISC/pair_cdeam.h
@@ -49,6 +49,8 @@ public:
   /// Reports the memory usage of this pair style to LAMMPS.
   double memory_usage();
 
+  void *extract(const char *, int &) { return NULL; }
+
   /// Parses the coefficients of the h polynomial from the end of the EAM file.
   void read_h_coeff(char* filename);
 

--- a/src/USER-OMP/pair_eam_omp.cpp
+++ b/src/USER-OMP/pair_eam_omp.cpp
@@ -203,7 +203,7 @@ void PairEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
     if (EFLAG) {
       phi = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
       if (rho[i] > rhomax) phi += fp[i] * (rho[i]-rhomax);
-      e_tally_thr(this, i, i, nlocal, NEWTON_PAIR, phi, 0.0, thr);
+      e_tally_thr(this, i, i, nlocal, NEWTON_PAIR, scale[type[i]][type[i]]*phi, 0.0, thr);
     }
   }
 
@@ -230,6 +230,7 @@ void PairEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
     ztmp = x[i].z;
     itype = type[i];
     fxtmp = fytmp = fztmp = 0.0;
+    const double * _noalias const scale_i = scale[itype];
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
@@ -274,7 +275,7 @@ void PairEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
         phi = z2*recip;
         phip = z2p*recip - phi*recip;
         psip = fp[i]*rhojp + fp[j]*rhoip + phip;
-        fpair = -psip*recip;
+        fpair = -scale_i[jtype]*psip*recip;
 
         fxtmp += delx*fpair;
         fytmp += dely*fpair;
@@ -285,7 +286,7 @@ void PairEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
           f[j].z -= delz*fpair;
         }
 
-        if (EFLAG) evdwl = phi;
+        if (EFLAG) evdwl = scale_i[jtype]*phi;
         if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
                                  evdwl,0.0,fpair,delx,dely,delz,thr);
       }

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -321,7 +321,7 @@ void FixAdapt::init()
         delete[] psuffix;
       }
       if (ad->pair == NULL) ad->pair = force->pair_match(pstyle,1,nsub);
-      if (ad->pair == NULL) 
+      if (ad->pair == NULL)
         error->all(FLERR,"Fix adapt pair style does not exist");
 
       void *ptr = ad->pair->extract(ad->pparam,ad->pdim);


### PR DESCRIPTION
This pull request attempts to correct several issues with the changes to PairEAM in commit b9b044e180df898fe996276bc663217a1d088f8b:
- in PairEAM forces were scaled, but not energies
- port use of scale array to OPT and USER-OMP package
- scale array should be initialized to NULL in constructor
- PairEAM::extract() was declared virtual, so it can be overridden in derived classes that don't support fix adapt
- disable use of fix adapt on all EAM styles in KOKKOS & GPU, and for cdeam in USER-MISC and USER-OMP
