### PR TITLE
Adding quasirandom mesh option

### DIFF
--- a/doc/src/create_atoms.rst
+++ b/doc/src/create_atoms.rst
@@ -53,6 +53,8 @@ Syntax
          factor = scale factor for setting atom radius
        *radthresh* value = radius (distance units)
          radius = threshold value for *mesh* to determine when to split triangles
+       *quasirandom* value = number density (inverse distance squared units)
+         number density = minimum number density for particles placed on *mesh* triangles
        *rotate* values = theta Rx Ry Rz
          theta = rotation angle for single molecule (degrees)
          Rx,Ry,Rz = rotation vector for single molecule
@@ -148,6 +150,12 @@ one sphere per triangle.  If the atom style in use allows to set a
 per-atom radius this radius is set to the average distance of the
 triangle vertices from its center times the value of the *radscale*
 keyword (default: 1.0).
+The *mesh* style also has a *quasirandom* option which uses a quasirandom
+sequence to distribute particles on mesh triangles using an approach
+by :ref:`(Roberts) <Roberts2019>`. This option takes a minimal number
+density as an argument. Particles are added to the triangle until this
+number density is met or exceeded such that every triangle will have
+at least one particle.
 
 .. note::
 
@@ -509,3 +517,10 @@ assigned the argument *type* as their atom type (when single atoms are
 being created).  The other defaults are *remap* = no, *rotate* = random,
 *radscale* = 1.0, *radthresh* = x-lattice spacing, *overlap* not
 checked, *maxtry* = 10, and *units* = lattice.
+
+----------
+
+.. _Roberts2019:
+
+**(Roberts)** R. Roberts (2019) "Evenly Distributing Points in a Triangle." Extreme Learning.
+`<http://extremelearning.com.au/evenly-distributing-points-in-a-triangle/>`_

--- a/src/create_atoms.h
+++ b/src/create_atoms.h
@@ -41,7 +41,7 @@ class CreateAtoms : public Command {
   double subsetfrac;
   int *basistype;
   double xone[3], quatone[4];
-  double radthresh, radscale;
+  double radthresh, radscale, mesh_density;
 
   int varflag, vvar, xvar, yvar, zvar;
   char *vstr, *xstr, *ystr, *zstr;
@@ -54,6 +54,7 @@ class CreateAtoms : public Command {
 
   int *flag;    // flag subset of particles to insert on lattice
   int *next;
+  int mesh_style;
 
   class Region *region;
   class Molecule *onemol;
@@ -67,6 +68,7 @@ class CreateAtoms : public Command {
   void add_random();
   void add_mesh(const char *);
   int add_tricenter(const double [3][3], tagint);
+  int add_quasirandom(const double [3][3], tagint);
   void add_lattice();
   void loop_lattice(int);
   void add_molecule(double *);


### PR DESCRIPTION
**Summary**

Adding new option for STL-based atom creation using approach from [Roberts 2019](http://extremelearning.com.au/evenly-distributing-points-in-a-triangle/). 

**Author(s)**

jtclemm (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).